### PR TITLE
15 clean up messy logging behavior

### DIFF
--- a/src/models/bot.ts
+++ b/src/models/bot.ts
@@ -116,27 +116,6 @@ export class Bot {
 
     this.ready = true
     Logger.info(Logs.info.clientReady)
-
-    const ctaChannel = this.client.guilds.cache
-      .find((dggPol) => dggPol.name === guildName)
-      ?.channels.cache.find((ctaChan) => ctaChan?.name === ctaChannelName)
-    const d = new Date()
-
-    if (ctaChannel?.type === ChannelType.GuildAnnouncement) {
-      const ctaPostTrigger = new CTAPostTrigger()
-      await ctaPostTrigger.getChannelThreads(ctaChannel)
-
-      // fetch all CTA Channel messages
-      // for each that is less than a month old
-      // execute the ctaPostTrigger
-      ctaChannel.messages.fetch().then((msgs) => {
-        msgs.forEach((msg) => {
-          if (new Date(msg.createdTimestamp).getMonth() >= d.getMonth() - 1) {
-            ctaPostTrigger.execute(msg)
-          }
-        })
-      })
-    }
   }
 
   private onShardReady(shardId: number, _unavailableGuilds: Set<string>): void {

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -94,7 +94,9 @@ export class Logger {
   public static setShardId(shardId: number): void {
     if (this.shardId !== shardId) {
       this.shardId = shardId
-      logger = logger.child({ shardId })
+      // Commenting this because we don't care about sharding rn
+      // AND its quite spammy as an additional line per log message
+      //logger = logger.child({ shardId })
     }
   }
 }

--- a/src/triggers/cta-post.ts
+++ b/src/triggers/cta-post.ts
@@ -124,33 +124,6 @@ export class CTAPostTrigger implements Trigger {
     return roleReactions
   }
 
-  public async getChannelThreads(chan: GuildBasedChannel | undefined): Promise<void> {
-    Logger.info(`chanThreadsByMsg BEFORE: ${chanThreadsByMsg.size}`)
-    if (chan === undefined) {
-      return
-    }
-
-    if (chan.type != ChannelType.GuildAnnouncement) {
-      return
-    }
-
-    const activeThreads = await chan.threads.fetch()
-    const archivedThreads = await chan.threads.fetchArchived({ fetchAll: true })
-
-    chanThreadsByMsg = new Map([
-      ...activeThreads.threads.entries(),
-      ...archivedThreads.threads.entries(),
-    ])
-    Logger.info(`chanThreadsByMsg AFTER: ${chanThreadsByMsg.size}`)
-  }
-
-  private async activeCTAThread(msg: Message): Promise<PublicThreadChannel | undefined> {
-    Logger.info(`activeCTAThread() [START]: ${msg.id}`)
-    if (msg.hasThread && msg.thread?.type === ChannelType.PublicThread && !msg.thread?.archived) {
-      return msg.thread
-    }
-  }
-
   private async createCTAThread(msg: Message): Promise<PublicThreadChannel | undefined> {
     Logger.info(`createCTAThread() [START]: ${msg.id}`)
 


### PR DESCRIPTION
This PR is targeting a logging clean up of some of the older code. I removed the `shardId` log message that made every log statement two lines. I also removed some test code that was printing log statements from test servers that the bot still lives on. Now the startup is free from useless noise!

I think I'll make a separate PR to add better startup logging that indicates the services, triggers, commands, etc. that are all instantiated.