### PR TITLE
attendance tracker x CRM expansion (redo)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,12 @@ DISCORD_CLIENT_ID="id"
 DISCORD_BOT_TOKEN="token"
 DISCORD_BOT_DEVELOPER_IDS="123456789012345678"
 
+# CRM integration: required for /attendance-track to post staged attendance.
+# Local dev: point at the in-house-mgmt server (default port 8080) and a token
+# created in Django admin → Auth → Tokens for a user in the DISCORD_BOT group.
+CRM_API_URL="http://localhost:8080"
+CRM_API_TOKEN="paste-token-from-django-admin"
+
 # optional: hourly sync of Discord scheduled events → DGGP Google Calendar (service account)
 # GOOGLE_CALENDAR_ID="your-calendar-id@group.calendar.google.com"
 # GOOGLE_APPLICATION_CREDENTIALS="path/to/service-account.json"

--- a/lang/lang.en-US.json
+++ b/lang/lang.en-US.json
@@ -150,13 +150,13 @@
         "description": "You're already taking attendance in another channel. Leave that channel first to get your list, then run this again in a new channel if needed."
       },
       "attendanceNotAuthorized": {
-        "description": "You're not authorized to record attendance. Ask an organizer to grant you the **events.record_attendance** permission in the CRM."
+        "description": "Tracking **{{CHANNEL_NAME}}**. ⚠️ You don't have CRM permission to record attendance, so the roster won't be synced — I'll DM you the list when you leave. Ask an organizer to grant you the **events.record_attendance** permission in the CRM."
       },
       "attendanceUnlinkedDiscordId": {
-        "description": "Your Discord account isn't linked to a CRM user, so attendance can't be recorded under your name. Ask an organizer to link your Discord ID in the CRM."
+        "description": "Tracking **{{CHANNEL_NAME}}**. ⚠️ Your Discord account isn't linked to a CRM user, so attendance won't be synced — I'll DM you the list when you leave. Ask an organizer to link your Discord ID in the CRM."
       },
       "attendancePermissionCheckFailed": {
-        "description": "Couldn't verify your authorization with the CRM right now. Try again in a moment, or ping an organizer if it keeps failing."
+        "description": "Tracking **{{CHANNEL_NAME}}**. ⚠️ Couldn't reach the CRM to verify your permissions, so attendance won't be synced — I'll DM you the list when you leave."
       }
     },
     "validationEmbeds": {

--- a/lang/lang.en-US.json
+++ b/lang/lang.en-US.json
@@ -148,6 +148,15 @@
       },
       "attendanceAlreadyTracking": {
         "description": "You're already taking attendance in another channel. Leave that channel first to get your list, then run this again in a new channel if needed."
+      },
+      "attendanceNotAuthorized": {
+        "description": "You're not authorized to record attendance. Ask an organizer to grant you the **events.record_attendance** permission in the CRM."
+      },
+      "attendanceUnlinkedDiscordId": {
+        "description": "Your Discord account isn't linked to a CRM user, so attendance can't be recorded under your name. Ask an organizer to link your Discord ID in the CRM."
+      },
+      "attendancePermissionCheckFailed": {
+        "description": "Couldn't verify your authorization with the CRM right now. Try again in a moment, or ping an organizer if it keeps failing."
       }
     },
     "validationEmbeds": {

--- a/lang/lang.en-US.json
+++ b/lang/lang.en-US.json
@@ -258,7 +258,8 @@
     "arguments": {
       "command": "command",
       "option": "option",
-      "ruleNumber": "rulenumber"
+      "ruleNumber": "rulenumber",
+      "attendanceEventName": "name"
     },
     "commandDescs": {
       "dev": "Developer use only.",
@@ -275,7 +276,8 @@
       "devCommand": "Command.",
       "helpOption": "Option.",
       "infoOption": "Option.",
-      "ruleNumber": "Rule number."
+      "ruleNumber": "Rule number.",
+      "attendanceEventName": "Override the default event name (scheduled-event name, or channel + start time)."
     },
     "fields": {
       "commands": "Commands",

--- a/src/commands/args.ts
+++ b/src/commands/args.ts
@@ -68,4 +68,13 @@ export class Args {
     min_value: 1,
     max_value: Rules.ServerRules.length,
   }
+  public static readonly ATTENDANCE_TRACK_NAME: APIApplicationCommandBasicOption = {
+    name: Lang.getRef('arguments.attendanceEventName', Language.Default),
+    name_localizations: Lang.getRefLocalizationMap('arguments.attendanceEventName'),
+    description: Lang.getRef('argDescs.attendanceEventName', Language.Default),
+    description_localizations: Lang.getRefLocalizationMap('argDescs.attendanceEventName'),
+    type: ApplicationCommandOptionType.String,
+    required: false,
+    max_length: 100,
+  }
 }

--- a/src/commands/chat/attendance-track-command.ts
+++ b/src/commands/chat/attendance-track-command.ts
@@ -19,9 +19,13 @@ import { Logger } from '../../services/logger.js'
 import { InteractionUtils } from '../../utils/index.js'
 import { type Command, CommandDeferType } from '../index.js'
 
-// 'ok' intentionally absent — the caller branches on authorized first.
-// 'missing_tracker' falls back to the generic message because the bot
-// always supplies a discord_id, so the CRM should never report it.
+// Maps each CRM rejection reason to the lang key for the user-facing message.
+// Two variants of AttendancePermissionReason are intentionally not in this map:
+//   - 'ok'             — authorized=true short-circuits before we reach this lookup.
+//   - 'missing_tracker' — the bot always supplies a discord_id, so the CRM
+//                         should never return this code in practice. If it ever
+//                         does, the missing entry falls through to FALLBACK_LANG_KEY
+//                         and the user sees the generic "couldn't verify" message.
 const REASON_TO_LANG_KEY: Partial<Record<AttendancePermissionReason, string>> = {
   not_authorized: 'displayEmbeds.attendanceNotAuthorized',
   unlinked_discord_id: 'displayEmbeds.attendanceUnlinkedDiscordId',
@@ -87,6 +91,10 @@ export class AttendanceTrackCommand implements Command {
       return
     }
 
+    const customName = intr.options.getString(
+      Lang.getRef('arguments.attendanceEventName', Language.Default),
+    )
+
     const initialMembers = Array.from(voiceChannel.members.values()).map((m) => ({
       id: m.id,
       displayName: m.displayName ?? m.user.username ?? 'Unknown',
@@ -98,6 +106,7 @@ export class AttendanceTrackCommand implements Command {
       voiceChannel.guild.id,
       voiceChannel.name,
       initialMembers,
+      customName ?? undefined,
     )
 
     if (!started) {

--- a/src/commands/chat/attendance-track-command.ts
+++ b/src/commands/chat/attendance-track-command.ts
@@ -8,30 +8,21 @@ import {
 import { RateLimiter } from 'discord.js-rate-limiter'
 import { Language } from '../../models/enum-helpers/index.js'
 import { type EventData } from '../../models/internal-models.js'
-import type { AttendanceService } from '../../services/attendance-service.js'
 import {
-  type AttendancePermissionReason,
-  type CrmAttendancePermissionResponse,
-  type CrmService,
-} from '../../services/crm-service.js'
+  type AttendanceService,
+  type CrmDisabledReason,
+} from '../../services/attendance-service.js'
+import { type CrmService } from '../../services/crm-service.js'
 import { Lang } from '../../services/index.js'
 import { Logger } from '../../services/logger.js'
 import { InteractionUtils } from '../../utils/index.js'
 import { type Command, CommandDeferType } from '../index.js'
 
-// Maps each CRM rejection reason to the lang key for the user-facing message.
-// Two variants of AttendancePermissionReason are intentionally not in this map:
-//   - 'ok'             — authorized=true short-circuits before we reach this lookup.
-//   - 'missing_tracker' — the bot always supplies a discord_id, so the CRM
-//                         should never return this code in practice. If it ever
-//                         does, the missing entry falls through to FALLBACK_LANG_KEY
-//                         and the user sees the generic "couldn't verify" message.
-const REASON_TO_LANG_KEY: Partial<Record<AttendancePermissionReason, string>> = {
+const REASON_TO_LANG_KEY: Record<CrmDisabledReason, string> = {
   not_authorized: 'displayEmbeds.attendanceNotAuthorized',
   unlinked_discord_id: 'displayEmbeds.attendanceUnlinkedDiscordId',
+  check_failed: 'displayEmbeds.attendancePermissionCheckFailed',
 }
-
-const FALLBACK_LANG_KEY = 'displayEmbeds.attendancePermissionCheckFailed'
 
 export class AttendanceTrackCommand implements Command {
   public names = [Lang.getRef('chatCommands.attendanceTrack', Language.Default)]
@@ -76,19 +67,18 @@ export class AttendanceTrackCommand implements Command {
       return
     }
 
-    let permission: CrmAttendancePermissionResponse
+    let crmDisabledReason: CrmDisabledReason | undefined
     try {
-      permission = await this.crmService.checkAttendancePermission(intr.user.id)
+      const permission = await this.crmService.checkAttendancePermission(intr.user.id)
+      if (!permission.authorized) {
+        crmDisabledReason =
+          permission.reason === 'not_authorized' || permission.reason === 'unlinked_discord_id'
+            ? permission.reason
+            : 'check_failed'
+      }
     } catch (error) {
       Logger.error('CRM can-record-attendance check failed', error)
-      await InteractionUtils.send(intr, Lang.getEmbed(FALLBACK_LANG_KEY, data.lang), true)
-      return
-    }
-
-    if (!permission.authorized) {
-      const langKey = REASON_TO_LANG_KEY[permission.reason] ?? FALLBACK_LANG_KEY
-      await InteractionUtils.send(intr, Lang.getEmbed(langKey, data.lang), true)
-      return
+      crmDisabledReason = 'check_failed'
     }
 
     const customName = intr.options.getString(
@@ -107,12 +97,24 @@ export class AttendanceTrackCommand implements Command {
       voiceChannel.name,
       initialMembers,
       customName ?? undefined,
+      crmDisabledReason,
     )
 
     if (!started) {
       await InteractionUtils.send(
         intr,
         Lang.getEmbed('displayEmbeds.attendanceAlreadyTracking', data.lang),
+        true,
+      )
+      return
+    }
+
+    if (crmDisabledReason) {
+      await InteractionUtils.send(
+        intr,
+        Lang.getEmbed(REASON_TO_LANG_KEY[crmDisabledReason], data.lang, {
+          CHANNEL_NAME: voiceChannel.name,
+        }),
         true,
       )
       return

--- a/src/commands/chat/attendance-track-command.ts
+++ b/src/commands/chat/attendance-track-command.ts
@@ -9,9 +9,25 @@ import { RateLimiter } from 'discord.js-rate-limiter'
 import { Language } from '../../models/enum-helpers/index.js'
 import { type EventData } from '../../models/internal-models.js'
 import type { AttendanceService } from '../../services/attendance-service.js'
+import {
+  type AttendancePermissionReason,
+  type CrmAttendancePermissionResponse,
+  type CrmService,
+} from '../../services/crm-service.js'
 import { Lang } from '../../services/index.js'
+import { Logger } from '../../services/logger.js'
 import { InteractionUtils } from '../../utils/index.js'
 import { type Command, CommandDeferType } from '../index.js'
+
+// 'ok' intentionally absent — the caller branches on authorized first.
+// 'missing_tracker' falls back to the generic message because the bot
+// always supplies a discord_id, so the CRM should never report it.
+const REASON_TO_LANG_KEY: Partial<Record<AttendancePermissionReason, string>> = {
+  not_authorized: 'displayEmbeds.attendanceNotAuthorized',
+  unlinked_discord_id: 'displayEmbeds.attendanceUnlinkedDiscordId',
+}
+
+const FALLBACK_LANG_KEY = 'displayEmbeds.attendancePermissionCheckFailed'
 
 export class AttendanceTrackCommand implements Command {
   public names = [Lang.getRef('chatCommands.attendanceTrack', Language.Default)]
@@ -19,7 +35,10 @@ export class AttendanceTrackCommand implements Command {
   public deferType = CommandDeferType.PUBLIC
   public requireClientPerms: PermissionsString[] = []
 
-  constructor(private readonly attendanceService: AttendanceService) {}
+  constructor(
+    private readonly attendanceService: AttendanceService,
+    private readonly crmService: CrmService,
+  ) {}
 
   public async execute(intr: ChatInputCommandInteraction, data: EventData): Promise<void> {
     if (!intr.guild) {
@@ -50,6 +69,21 @@ export class AttendanceTrackCommand implements Command {
         Lang.getEmbed('displayEmbeds.attendanceAlreadyTracking', data.lang),
         true,
       )
+      return
+    }
+
+    let permission: CrmAttendancePermissionResponse
+    try {
+      permission = await this.crmService.checkAttendancePermission(intr.user.id)
+    } catch (error) {
+      Logger.error('CRM can-record-attendance check failed', error)
+      await InteractionUtils.send(intr, Lang.getEmbed(FALLBACK_LANG_KEY, data.lang), true)
+      return
+    }
+
+    if (!permission.authorized) {
+      const langKey = REASON_TO_LANG_KEY[permission.reason] ?? FALLBACK_LANG_KEY
+      await InteractionUtils.send(intr, Lang.getEmbed(langKey, data.lang), true)
       return
     }
 

--- a/src/commands/metadata.ts
+++ b/src/commands/metadata.ts
@@ -115,6 +115,7 @@ export const ChatCommandMetadata: {
     description: Lang.getRef('commandDescs.attendanceTrack', Language.Default),
     description_localizations: Lang.getRefLocalizationMap('commandDescs.attendanceTrack'),
     default_member_permissions: undefined,
+    options: [Args.ATTENDANCE_TRACK_NAME],
   },
 }
 

--- a/src/events/voice-state-update-handler.ts
+++ b/src/events/voice-state-update-handler.ts
@@ -1,17 +1,27 @@
-import type { Client, VoiceState } from 'discord.js'
+import {
+  AttachmentBuilder,
+  StageChannel,
+  escapeMarkdown,
+  type Client,
+  type User,
+  type VoiceState,
+} from 'discord.js'
 
 import { type EventHandler } from './event-handler.js'
 import {
+  type AttendanceEntry,
   AttendanceService,
   formatAttendanceDmContent,
-  resolveVoiceChannelMeetingSubject,
+  resolveScheduledEvent,
 } from '../services/attendance-service.js'
+import { type CrmAttendancePayload, type CrmService } from '../services/crm-service.js'
 import { Logger } from '../services/logger.js'
 import { MessageUtils } from '../utils/message-utils.js'
 
 export class VoiceStateUpdateHandler implements EventHandler {
   constructor(
     private readonly attendanceService: AttendanceService,
+    private readonly crmService: CrmService,
     private readonly client: Client,
   ) {}
 
@@ -21,21 +31,133 @@ export class VoiceStateUpdateHandler implements EventHandler {
 
     const { userId, guildId, channelId, channelName, entries } = result
     try {
-      const user = await this.client.users.fetch(userId)
       const guild = await this.client.guilds.fetch(guildId)
-      const channel = await guild.channels.fetch(channelId).catch(() => null)
-      const meetingSubject = await resolveVoiceChannelMeetingSubject(guild, channelId, channel)
-      await MessageUtils.send(
-        user,
-        formatAttendanceDmContent({
+      const [user, channel, scheduledEvent] = await Promise.all([
+        this.client.users.fetch(userId),
+        guild.channels.fetch(channelId).catch(() => null),
+        resolveScheduledEvent(guild, channelId),
+      ])
+
+      if (!scheduledEvent) {
+        const meetingSubject =
+          channel instanceof StageChannel && channel.topic ? channel.topic : undefined
+        await this.sendFallbackDm(
+          user,
           channelName,
           meetingSubject,
           entries,
-          at: new Date(),
-        }),
-      )
+          'No scheduled event was linked to this channel, so nothing was synced to the CRM.',
+          null,
+        )
+        return
+      }
+
+      const payload: CrmAttendancePayload = {
+        event_id: scheduledEvent.id,
+        event_name: scheduledEvent.name,
+        event_tracker: userId,
+        participants: entries.map((e) => ({
+          discord_id: e.id,
+          discord_name: e.displayName,
+          status: 'ATTENDED',
+        })),
+      }
+
+      try {
+        const response = await this.crmService.recordAttendance(payload)
+
+        try {
+          const sent = await MessageUtils.send(
+            user,
+            this.formatCrmReportDm(
+              scheduledEvent.name,
+              channelName,
+              response.total_received,
+              response.unlinked_participants,
+            ),
+          )
+          if (!sent) {
+            Logger.warn(
+              `Attendance DM could not be delivered to ${userId} (DMs closed?). CRM row still written for event ${scheduledEvent.id}.`,
+            )
+          }
+        } catch (dmError) {
+          Logger.warn(
+            `CRM row written for event ${scheduledEvent.id} but delivering the success DM threw: ${String(dmError)}`,
+          )
+        }
+      } catch (error) {
+        Logger.error('CRM record-attendance failed', error)
+        await this.sendFallbackDm(
+          user,
+          channelName,
+          scheduledEvent.name,
+          entries,
+          'Failed to sync attendance to the CRM. The raw payload is below so it can be replayed manually.',
+          payload,
+        )
+      }
     } catch (error) {
-      Logger.error('Failed to send attendance DM', error)
+      Logger.error('Failed to process voice state update for attendance', error)
     }
+  }
+
+  private async sendFallbackDm(
+    user: User,
+    channelName: string,
+    meetingSubject: string | undefined,
+    entries: AttendanceEntry[],
+    note: string,
+    payload: CrmAttendancePayload | null,
+  ): Promise<void> {
+    await MessageUtils.send(user, `:warning: ${note}`)
+
+    const reportContent = formatAttendanceDmContent({
+      channelName,
+      meetingSubject,
+      entries,
+      at: new Date(),
+    })
+
+    if (payload) {
+      const buffer = Buffer.from(JSON.stringify(payload, null, 2), 'utf8')
+      const attachment = new AttachmentBuilder(buffer, {
+        name: `attendance-${payload.event_id}.json`,
+      })
+      await MessageUtils.send(user, {
+        content: `${reportContent}\n**Raw CRM payload (for manual replay):**`,
+        files: [attachment],
+      })
+    } else {
+      await MessageUtils.send(user, reportContent)
+    }
+  }
+
+  private formatCrmReportDm(
+    eventName: string,
+    channelName: string,
+    total: number,
+    unlinked: Array<{ discord_id: string; discord_name: string }>,
+  ): string {
+    const noneLinked = unlinked.length === total && total > 0
+    const plural = total === 1 ? '' : 's'
+    const tail = noneLinked
+      ? ', but none can be uploaded yet — no CRM contact matches.'
+      : '. Go to the CRM to finish the upload into the event.'
+    const lines: string[] = [
+      '**Attendance staged in CRM** :white_check_mark:',
+      `Event: **${escapeMarkdown(eventName)}** (${escapeMarkdown(channelName)})`,
+      `All ${total} attendee${plural} recorded${tail}`,
+    ]
+
+    if (unlinked.length > 0) {
+      lines.push('')
+      lines.push(
+        `:warning: **Need a CRM contact before they can be uploaded (${unlinked.length}):**`,
+      )
+      for (const u of unlinked) lines.push(`- ${escapeMarkdown(u.discord_name)}`)
+    }
+
+    return lines.join('\n')
   }
 }

--- a/src/events/voice-state-update-handler.ts
+++ b/src/events/voice-state-update-handler.ts
@@ -55,7 +55,7 @@ export class VoiceStateUpdateHandler implements EventHandler {
       const payload: CrmAttendancePayload = {
         event_id: scheduledEvent.id,
         event_name: scheduledEvent.name,
-        event_tracker: userId,
+        event_tracker_discord_id: userId,
         participants: entries.map((e) => ({
           discord_id: e.id,
           discord_name: e.displayName,

--- a/src/events/voice-state-update-handler.ts
+++ b/src/events/voice-state-update-handler.ts
@@ -46,7 +46,7 @@ export class VoiceStateUpdateHandler implements EventHandler {
       ])
 
       //name must be provided
-      //either default - event name or channel name + date
+      //default - event name or channel name + date
       //provide arg for custom name
       const eventId = scheduledEvent?.id ?? sessionId
       const displayEventName = customEventName ?? scheduledEvent?.name ?? defaultEventName
@@ -118,17 +118,17 @@ export class VoiceStateUpdateHandler implements EventHandler {
       at: new Date(),
     })
 
+    await MessageUtils.send(user, reportContent)
+
     if (payload) {
       const buffer = Buffer.from(JSON.stringify(payload, null, 2), 'utf8')
       const attachment = new AttachmentBuilder(buffer, {
         name: `attendance-${payload.event_id}.json`,
       })
       await MessageUtils.send(user, {
-        content: `${reportContent}\n**Raw CRM payload (for manual replay):**`,
+        content: '**Raw CRM payload (for manual replay):**',
         files: [attachment],
       })
-    } else {
-      await MessageUtils.send(user, reportContent)
     }
   }
 

--- a/src/events/voice-state-update-handler.ts
+++ b/src/events/voice-state-update-handler.ts
@@ -10,12 +10,22 @@ import { type EventHandler } from './event-handler.js'
 import {
   type AttendanceEntry,
   AttendanceService,
+  type CrmDisabledReason,
   formatAttendanceDmContent,
   resolveScheduledEvent,
 } from '../services/attendance-service.js'
 import { type CrmAttendancePayload, type CrmService } from '../services/crm-service.js'
 import { Logger } from '../services/logger.js'
 import { MessageUtils } from '../utils/message-utils.js'
+
+const CRM_DISABLED_DM_NOTES: Record<CrmDisabledReason, string> = {
+  not_authorized:
+    "You weren't authorized to record CRM attendance, so this list wasn't synced — keep it for your records.",
+  unlinked_discord_id:
+    "Your Discord account isn't linked to a CRM user, so this list wasn't synced — keep it for your records.",
+  check_failed:
+    "The CRM was unreachable when tracking started, so this list wasn't synced — keep it for your records.",
+}
 
 export class VoiceStateUpdateHandler implements EventHandler {
   constructor(
@@ -37,6 +47,7 @@ export class VoiceStateUpdateHandler implements EventHandler {
       defaultEventName,
       customEventName,
       entries,
+      crmDisabledReason,
     } = result
     try {
       const guild = await this.client.guilds.fetch(guildId)
@@ -50,6 +61,18 @@ export class VoiceStateUpdateHandler implements EventHandler {
       //provide arg for custom name
       const eventId = scheduledEvent?.id ?? sessionId
       const displayEventName = customEventName ?? scheduledEvent?.name ?? defaultEventName
+
+      if (crmDisabledReason) {
+        await this.sendFallbackDm(
+          user,
+          channelName,
+          displayEventName,
+          entries,
+          CRM_DISABLED_DM_NOTES[crmDisabledReason],
+          null,
+        )
+        return
+      }
 
       const payload: CrmAttendancePayload = {
         event_id: eventId,

--- a/src/events/voice-state-update-handler.ts
+++ b/src/events/voice-state-update-handler.ts
@@ -1,6 +1,5 @@
 import {
   AttachmentBuilder,
-  StageChannel,
   escapeMarkdown,
   type Client,
   type User,
@@ -29,32 +28,32 @@ export class VoiceStateUpdateHandler implements EventHandler {
     const result = this.attendanceService.handleVoiceStateUpdate(oldState, newState)
     if (!result) return
 
-    const { userId, guildId, channelId, channelName, entries } = result
+    const {
+      userId,
+      guildId,
+      channelId,
+      channelName,
+      sessionId,
+      defaultEventName,
+      customEventName,
+      entries,
+    } = result
     try {
       const guild = await this.client.guilds.fetch(guildId)
-      const [user, channel, scheduledEvent] = await Promise.all([
+      const [user, scheduledEvent] = await Promise.all([
         this.client.users.fetch(userId),
-        guild.channels.fetch(channelId).catch(() => null),
         resolveScheduledEvent(guild, channelId),
       ])
 
-      if (!scheduledEvent) {
-        const meetingSubject =
-          channel instanceof StageChannel && channel.topic ? channel.topic : undefined
-        await this.sendFallbackDm(
-          user,
-          channelName,
-          meetingSubject,
-          entries,
-          'No scheduled event was linked to this channel, so nothing was synced to the CRM.',
-          null,
-        )
-        return
-      }
+      //name must be provided
+      //either default - event name or channel name + date
+      //provide arg for custom name
+      const eventId = scheduledEvent?.id ?? sessionId
+      const displayEventName = customEventName ?? scheduledEvent?.name ?? defaultEventName
 
       const payload: CrmAttendancePayload = {
-        event_id: scheduledEvent.id,
-        event_name: scheduledEvent.name,
+        event_id: eventId,
+        event_name: displayEventName,
         event_tracker_discord_id: userId,
         participants: entries.map((e) => ({
           discord_id: e.id,
@@ -70,7 +69,7 @@ export class VoiceStateUpdateHandler implements EventHandler {
           const sent = await MessageUtils.send(
             user,
             this.formatCrmReportDm(
-              scheduledEvent.name,
+              displayEventName,
               channelName,
               response.total_received,
               response.unlinked_participants,
@@ -78,12 +77,12 @@ export class VoiceStateUpdateHandler implements EventHandler {
           )
           if (!sent) {
             Logger.warn(
-              `Attendance DM could not be delivered to ${userId} (DMs closed?). CRM row still written for event ${scheduledEvent.id}.`,
+              `Attendance DM could not be delivered to ${userId} (DMs closed?). CRM row still written for event ${eventId}.`,
             )
           }
         } catch (dmError) {
           Logger.warn(
-            `CRM row written for event ${scheduledEvent.id} but delivering the success DM threw: ${String(dmError)}`,
+            `CRM row written for event ${eventId} but delivering the success DM threw: ${String(dmError)}`,
           )
         }
       } catch (error) {
@@ -91,7 +90,7 @@ export class VoiceStateUpdateHandler implements EventHandler {
         await this.sendFallbackDm(
           user,
           channelName,
-          scheduledEvent.name,
+          displayEventName,
           entries,
           'Failed to sync attendance to the CRM. The raw payload is below so it can be replayed manually.',
           payload,

--- a/src/services/attendance-service.ts
+++ b/src/services/attendance-service.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto'
+
 import {
   GuildScheduledEventStatus,
   StageChannel,
@@ -6,6 +8,8 @@ import {
   type VoiceState,
 } from 'discord.js'
 import { DateTime } from 'luxon'
+
+import { StringUtils } from '../utils/string-utils.js'
 
 export interface AttendanceEntry {
   id: string
@@ -101,6 +105,16 @@ export async function resolveVoiceChannelMeetingSubject(
 }
 
 interface AttendanceSession {
+  /** Synthetic identifier used as event_id when no Discord scheduled event is linked.
+   * Stable for the lifetime of the tracking session so retries / multi-step CRM
+   * writes converge on the same StagedEvent row. */
+  sessionId: string
+  /** Synthetic event name ("<channel name> — <UTC start time>") used when there's
+   * no scheduled event AND the tracker didn't provide a custom name. */
+  defaultEventName: string
+  /** Optional override the tracker passed via the slash-command's name argument.
+   * When set, this wins over both the scheduled-event name and the default. */
+  customEventName?: string
   channelId: string
   guildId: string
   channelName: string
@@ -127,6 +141,7 @@ export class AttendanceService {
     guildId: string,
     channelName: string,
     initialMembers: Array<{ id: string; displayName: string }>,
+    customName?: string,
   ): boolean {
     if (this.sessions.has(userId)) {
       return false
@@ -135,7 +150,16 @@ export class AttendanceService {
     for (const m of initialMembers) {
       members.set(m.id, m.displayName)
     }
+    const trimmedCustomName = customName?.trim()
+    const startedAt = DateTime.utc()
+    const defaultEventName = StringUtils.truncate(
+      `${channelName} — ${startedAt.toFormat("LLL d, yyyy h:mm a 'UTC'")}`,
+      100,
+    )
     this.sessions.set(userId, {
+      sessionId: randomUUID(),
+      defaultEventName,
+      customEventName: trimmedCustomName ? StringUtils.truncate(trimmedCustomName, 100) : undefined,
       channelId,
       guildId,
       channelName,
@@ -157,6 +181,9 @@ export class AttendanceService {
     guildId: string
     channelId: string
     channelName: string
+    sessionId: string
+    defaultEventName: string
+    customEventName?: string
     entries: AttendanceEntry[]
   } | null {
     const memberId = newState.member?.id ?? oldState.member?.id
@@ -190,6 +217,9 @@ export class AttendanceService {
         guildId: session.guildId,
         channelId: session.channelId,
         channelName: session.channelName,
+        sessionId: session.sessionId,
+        defaultEventName: session.defaultEventName,
+        customEventName: session.customEventName,
         entries,
       }
     }

--- a/src/services/attendance-service.ts
+++ b/src/services/attendance-service.ts
@@ -87,6 +87,19 @@ export async function resolveScheduledEvent(
 }
 
 /**
+ * Pure derivation: scheduled event name if present, else stage topic when `channel` is a
+ * stage with a topic. Use this when the scheduled event was already resolved upstream.
+ */
+export function meetingSubjectFrom(
+  scheduledEvent: { name: string } | null,
+  channel: GuildBasedChannel | null,
+): string | undefined {
+  if (scheduledEvent) return scheduledEvent.name
+  if (channel instanceof StageChannel && channel.topic) return channel.topic
+  return undefined
+}
+
+/**
  * Active scheduled event linked to this voice/stage channel, else stage topic when `channel` is a
  * stage with a topic. Uses `voiceChannelId` so scheduled events still resolve if the channel was
  * deleted before the DM is sent (e.g. end of `/attendance-track`).
@@ -97,12 +110,15 @@ export async function resolveVoiceChannelMeetingSubject(
   channel?: GuildBasedChannel | null,
 ): Promise<string | undefined> {
   const active = await resolveScheduledEvent(guild, voiceChannelId)
-  if (active) return active.name
-  if (channel instanceof StageChannel && channel.topic) {
-    return channel.topic
-  }
-  return undefined
+  return meetingSubjectFrom(active, channel ?? null)
 }
+
+/**
+ * Why CRM sync is off for a session. Set at `/attendance-track` invocation when the preflight
+ * permission check rejects or errors. Tracking still proceeds; the handler skips the CRM call
+ * at session end and tells the user why.
+ */
+export type CrmDisabledReason = 'not_authorized' | 'unlinked_discord_id' | 'check_failed'
 
 interface AttendanceSession {
   /** Synthetic identifier used as event_id when no Discord scheduled event is linked.
@@ -120,6 +136,7 @@ interface AttendanceSession {
   channelName: string
   /** Cumulative: everyone in the call when tracking started, plus anyone who joins later. */
   members: Map<string, string>
+  crmDisabledReason?: CrmDisabledReason
 }
 
 /**
@@ -142,6 +159,7 @@ export class AttendanceService {
     channelName: string,
     initialMembers: Array<{ id: string; displayName: string }>,
     customName?: string,
+    crmDisabledReason?: CrmDisabledReason,
   ): boolean {
     if (this.sessions.has(userId)) {
       return false
@@ -164,6 +182,7 @@ export class AttendanceService {
       guildId,
       channelName,
       members,
+      crmDisabledReason,
     })
     return true
   }
@@ -185,6 +204,7 @@ export class AttendanceService {
     defaultEventName: string
     customEventName?: string
     entries: AttendanceEntry[]
+    crmDisabledReason?: CrmDisabledReason
   } | null {
     const memberId = newState.member?.id ?? oldState.member?.id
     if (!memberId) return null
@@ -221,6 +241,7 @@ export class AttendanceService {
         defaultEventName: session.defaultEventName,
         customEventName: session.customEventName,
         entries,
+        crmDisabledReason: session.crmDisabledReason,
       }
     }
 

--- a/src/services/attendance-service.ts
+++ b/src/services/attendance-service.ts
@@ -59,6 +59,30 @@ export function formatAttendanceDmContent(payload: AttendanceDmPayload): string 
 }
 
 /**
+ * Active scheduled event linked to this voice/stage channel. Returns both id and name so the
+ * bot can identify the event when pushing attendance to the CRM.
+ */
+export async function resolveScheduledEvent(
+  guild: Guild,
+  voiceChannelId: string,
+): Promise<{ id: string; name: string } | null> {
+  const cached = [...guild.scheduledEvents.cache.values()].find(
+    (e) => e.channelId === voiceChannelId && e.status === GuildScheduledEventStatus.Active,
+  )
+  if (cached) return { id: cached.id, name: cached.name }
+  try {
+    const events = await guild.scheduledEvents.fetch()
+    const active = [...events.values()].find(
+      (e) => e.channelId === voiceChannelId && e.status === GuildScheduledEventStatus.Active,
+    )
+    if (active) return { id: active.id, name: active.name }
+  } catch {
+    // swallow: perms/API error — null is the "no linked event" signal
+  }
+  return null
+}
+
+/**
  * Active scheduled event linked to this voice/stage channel, else stage topic when `channel` is a
  * stage with a topic. Uses `voiceChannelId` so scheduled events still resolve if the channel was
  * deleted before the DM is sent (e.g. end of `/attendance-track`).
@@ -68,15 +92,8 @@ export async function resolveVoiceChannelMeetingSubject(
   voiceChannelId: string,
   channel?: GuildBasedChannel | null,
 ): Promise<string | undefined> {
-  try {
-    const events = await guild.scheduledEvents.fetch()
-    const active = [...events.values()].find(
-      (e) => e.channelId === voiceChannelId && e.status === GuildScheduledEventStatus.Active,
-    )
-    if (active) return active.name
-  } catch {
-    // Missing permissions or API error — fall through to stage topic
-  }
+  const active = await resolveScheduledEvent(guild, voiceChannelId)
+  if (active) return active.name
   if (channel instanceof StageChannel && channel.topic) {
     return channel.topic
   }

--- a/src/services/crm-service.ts
+++ b/src/services/crm-service.ts
@@ -1,8 +1,9 @@
-import fetch from 'node-fetch'
+import fetch, { type RequestInit } from 'node-fetch'
 import { URL } from 'node:url'
 
 const REQUEST_TIMEOUT_MS = 10_000
 const RECORD_ATTENDANCE_PATH = '/api/discord/record-attendance/'
+const CAN_RECORD_ATTENDANCE_PATH = '/api/discord/can-record-attendance/'
 
 export interface CrmAttendancePayload {
   event_id: string
@@ -24,6 +25,18 @@ export interface CrmAttendanceResponse {
   }>
 }
 
+// Mirrored from Server/dggcrm/discord/permissions.py — keep in sync.
+export type AttendancePermissionReason =
+  | 'ok'
+  | 'missing_tracker'
+  | 'unlinked_discord_id'
+  | 'not_authorized'
+
+export interface CrmAttendancePermissionResponse {
+  authorized: boolean
+  reason: AttendancePermissionReason
+}
+
 export class CrmService {
   private readonly baseUrl: URL
   private readonly token: string
@@ -43,28 +56,47 @@ export class CrmService {
   }
 
   public async recordAttendance(payload: CrmAttendancePayload): Promise<CrmAttendanceResponse> {
-    const url = new URL(RECORD_ATTENDANCE_PATH, this.baseUrl)
+    return this.request<CrmAttendanceResponse>('record-attendance', RECORD_ATTENDANCE_PATH, {
+      method: 'post',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+  }
+
+  public async checkAttendancePermission(
+    discordId: string,
+  ): Promise<CrmAttendancePermissionResponse> {
+    const url = new URL(CAN_RECORD_ATTENDANCE_PATH, this.baseUrl)
+    url.searchParams.set('discord_id', discordId)
+    return this.request<CrmAttendancePermissionResponse>(
+      'can-record-attendance',
+      url.pathname + url.search,
+      { method: 'get' },
+    )
+  }
+
+  private async request<T>(label: string, pathAndQuery: string, init: RequestInit): Promise<T> {
+    const url = new URL(pathAndQuery, this.baseUrl)
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
 
     try {
       const res = await fetch(url.toString(), {
-        method: 'post',
+        ...init,
         headers: {
           Authorization: `Token ${this.token}`,
-          'Content-Type': 'application/json',
           Accept: 'application/json',
+          ...init.headers,
         },
-        body: JSON.stringify(payload),
         signal: controller.signal,
       })
 
       if (!res.ok) {
         const text = await res.text().catch(() => '')
-        throw new Error(`CRM record-attendance failed: ${res.status} ${text}`)
+        throw new Error(`CRM ${label} failed: ${res.status} ${text}`)
       }
 
-      return (await res.json()) as CrmAttendanceResponse
+      return (await res.json()) as T
     } finally {
       clearTimeout(timer)
     }

--- a/src/services/crm-service.ts
+++ b/src/services/crm-service.ts
@@ -8,7 +8,7 @@ const CAN_RECORD_ATTENDANCE_PATH = '/api/discord/can-record-attendance/'
 export interface CrmAttendancePayload {
   event_id: string
   event_name: string
-  event_tracker: string
+  event_tracker_discord_id: string
   participants: Array<{
     discord_id: string
     discord_name: string

--- a/src/services/crm-service.ts
+++ b/src/services/crm-service.ts
@@ -1,0 +1,72 @@
+import fetch from 'node-fetch'
+import { URL } from 'node:url'
+
+const REQUEST_TIMEOUT_MS = 10_000
+const RECORD_ATTENDANCE_PATH = '/api/discord/record-attendance/'
+
+export interface CrmAttendancePayload {
+  event_id: string
+  event_name: string
+  event_tracker: string
+  participants: Array<{
+    discord_id: string
+    discord_name: string
+    status: 'ATTENDED'
+  }>
+}
+
+export interface CrmAttendanceResponse {
+  event_id: string
+  total_received: number
+  unlinked_participants: Array<{
+    discord_id: string
+    discord_name: string
+  }>
+}
+
+export class CrmService {
+  private readonly baseUrl: URL
+  private readonly token: string
+
+  constructor() {
+    const baseUrl = process.env.CRM_API_URL
+    const token = process.env.CRM_API_TOKEN
+    if (!baseUrl || !token) {
+      throw new Error('CRM_API_URL and CRM_API_TOKEN must be set')
+    }
+    try {
+      this.baseUrl = new URL(baseUrl)
+    } catch {
+      throw new Error(`CRM_API_URL is not a valid URL: ${baseUrl}`)
+    }
+    this.token = token
+  }
+
+  public async recordAttendance(payload: CrmAttendancePayload): Promise<CrmAttendanceResponse> {
+    const url = new URL(RECORD_ATTENDANCE_PATH, this.baseUrl)
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+    try {
+      const res = await fetch(url.toString(), {
+        method: 'post',
+        headers: {
+          Authorization: `Token ${this.token}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      })
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`CRM record-attendance failed: ${res.status} ${text}`)
+      }
+
+      return (await res.json()) as CrmAttendanceResponse
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/src/services/crm-service.ts
+++ b/src/services/crm-service.ts
@@ -2,7 +2,7 @@ import fetch, { type RequestInit } from 'node-fetch'
 import { URL } from 'node:url'
 
 const REQUEST_TIMEOUT_MS = 10_000
-const RECORD_ATTENDANCE_PATH = '/api/discord/record-attendance/'
+const RECORD_ATTENDANCE_PATH = '/api/discord/staged-event-participations/'
 const CAN_RECORD_ATTENDANCE_PATH = '/api/discord/can-record-attendance/'
 
 export interface CrmAttendancePayload {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,6 @@
 export { AttendanceService } from './attendance-service.js'
 export { CommandRegistrationService } from './command-registration-service.js'
+export { CrmService } from './crm-service.js'
 export { EventDataService } from './event-data-service.js'
 export { GoogleCalendarService } from './google-calendar-service.js'
 export { HttpService } from './http-service.js'

--- a/src/start-bot.ts
+++ b/src/start-bot.ts
@@ -101,7 +101,7 @@ async function start(): Promise<void> {
     new PragPapersCommand(),
     new CensusCommand(),
     new AttendanceCommand(),
-    new AttendanceTrackCommand(attendanceService),
+    new AttendanceTrackCommand(attendanceService, crmService),
 
     // User Context Commands
     ...ONBOARDING_CONFIGS.map((config) => new SendOnboarding(config)),

--- a/src/start-bot.ts
+++ b/src/start-bot.ts
@@ -72,6 +72,25 @@ async function start(): Promise<void> {
     process.exit(0)
   }
 
+  // Register
+  if (process.argv[2] == 'commands') {
+    try {
+      const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_BOT_TOKEN)
+      const commandRegistrationService = new CommandRegistrationService(rest)
+      const localCmds = [
+        ...Object.values(ChatCommandMetadata).sort((a, b) => (a.name > b.name ? 1 : -1)),
+        ...Object.values(MessageCommandMetadata).sort((a, b) => (a.name > b.name ? 1 : -1)),
+        ...Object.values(UserCommandMetadata).sort((a, b) => (a.name > b.name ? 1 : -1)),
+      ]
+      await commandRegistrationService.process(localCmds, process.argv)
+    } catch (error) {
+      Logger.error(Logs.error.commandAction, error)
+    }
+    // Wait for any final logs to be written.
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    process.exit()
+  }
+
   // Services
   const eventDataService = new EventDataService()
   const attendanceService = new AttendanceService()
@@ -166,25 +185,6 @@ async function start(): Promise<void> {
     new JobService(jobs),
     voiceStateUpdateHandler,
   )
-
-  // Register
-  if (process.argv[2] == 'commands') {
-    try {
-      const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_BOT_TOKEN)
-      const commandRegistrationService = new CommandRegistrationService(rest)
-      const localCmds = [
-        ...Object.values(ChatCommandMetadata).sort((a, b) => (a.name > b.name ? 1 : -1)),
-        ...Object.values(MessageCommandMetadata).sort((a, b) => (a.name > b.name ? 1 : -1)),
-        ...Object.values(UserCommandMetadata).sort((a, b) => (a.name > b.name ? 1 : -1)),
-      ]
-      await commandRegistrationService.process(localCmds, process.argv)
-    } catch (error) {
-      Logger.error(Logs.error.commandAction, error)
-    }
-    // Wait for any final logs to be written.
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    process.exit()
-  }
 
   await bot.start()
 }

--- a/src/start-bot.ts
+++ b/src/start-bot.ts
@@ -46,6 +46,7 @@ import { type Reaction } from './reactions/index.js'
 import {
   AttendanceService,
   CommandRegistrationService,
+  CrmService,
   EventDataService,
   GoogleCalendarService,
   JobService,
@@ -74,6 +75,7 @@ async function start(): Promise<void> {
   // Services
   const eventDataService = new EventDataService()
   const attendanceService = new AttendanceService()
+  const crmService = new CrmService()
 
   // Client
   const client = new CustomClient({
@@ -138,7 +140,7 @@ async function start(): Promise<void> {
   const messageHandler = new MessageHandler(triggerHandler)
   const reactionHandler = new ReactionHandler(reactions, eventDataService)
   const guildScheduledEventHandler = new GuildScheduledEventHandler(googleCalendarService)
-  const voiceStateUpdateHandler = new VoiceStateUpdateHandler(attendanceService, client)
+  const voiceStateUpdateHandler = new VoiceStateUpdateHandler(attendanceService, crmService, client)
 
   // Jobs
   // Google Calendar sync jobs temporarily disabled (see ImmediateSyncDggpGoogleCalendarJob, SyncDggpGoogleCalendarJob).


### PR DESCRIPTION
Includes an http client, wireshape, and post request. Note that a CRM token is needed for this, which I can provide

Was this change tested and if so how?
Yes, tested on a personal discord server

From a user's perspective what functionality/feature changed?
At a high level, the process is unchanged - trackers can still expect dms when they leave the channel or when the event ends. Digging a little deeper, there are a few changes these pr addresses

**1. Authorization on the caller - only users w/ the appropriate permissions on the crm side can run the command. The following are the possible non-happy path feedbacks the user can expect (both happy and non-happy feedback is sent via ephemeral message in the chat they run the command in)**

- not_authorized → "ask an organizer to grant you the events.record_attendance permission" 
- unlinked_discord_id → "Your Discord account isn't linked to a CRM user…"
- CRM throws / unknown reason → fallback "Couldn't verify your authorization with the CRM right now"

**2.  After an event, a request is fired and the response determines the contents of the dm**
- all attendees are CRM contacts
- some attendees are non CRM contacts (will still be stored and can be resolved CRM side)
- failed (on failure, the raw structure payload is added to the dm. one of the engineers of the project can push it manually and deep dive the fail)

Closes #69
