### PR TITLE
DM attendance roster with CRM staging success

### DIFF
--- a/src/commands/chat/attendance-command.ts
+++ b/src/commands/chat/attendance-command.ts
@@ -9,7 +9,9 @@ import { RateLimiter } from 'discord.js-rate-limiter'
 import { Language } from '../../models/enum-helpers/index.js'
 import { type EventData } from '../../models/internal-models.js'
 import {
-  formatAttendanceDmContent,
+  formatAttendanceContextText,
+  formatAttendanceRosterCodeBlock,
+  MESSAGE_CONTENT_MAX,
   resolveVoiceChannelMeetingSubject,
   type AttendanceEntry,
 } from '../../services/attendance-service.js'
@@ -57,14 +59,26 @@ export class AttendanceCommand implements Command {
       voiceChannel.id,
       voiceChannel,
     )
-    const dm = await MessageUtils.send(
-      intr.user,
-      formatAttendanceDmContent({
+    const summaryContent = formatAttendanceContextText({
+      channelName: voiceChannel.name,
+      meetingSubject,
+      entries,
+      at,
+    })
+    const reportContent = formatAttendanceRosterCodeBlock(
+      {
         channelName: voiceChannel.name,
         meetingSubject,
         entries,
         at,
-      }),
+      },
+      {
+        maxMessageLength: MESSAGE_CONTENT_MAX - summaryContent.length - 2,
+      },
+    )
+    const dm = await MessageUtils.send(
+      intr.user,
+      `${summaryContent}\n\n${reportContent}`,
     )
 
     if (!dm) {

--- a/src/commands/chat/attendance-command.ts
+++ b/src/commands/chat/attendance-command.ts
@@ -76,10 +76,7 @@ export class AttendanceCommand implements Command {
         maxMessageLength: MESSAGE_CONTENT_MAX - summaryContent.length - 2,
       },
     )
-    const dm = await MessageUtils.send(
-      intr.user,
-      `${summaryContent}\n\n${reportContent}`,
-    )
+    const dm = await MessageUtils.send(intr.user, `${summaryContent}\n\n${reportContent}`)
 
     if (!dm) {
       await InteractionUtils.send(

--- a/src/events/voice-state-update-handler.ts
+++ b/src/events/voice-state-update-handler.ts
@@ -200,10 +200,7 @@ export class VoiceStateUpdateHandler implements EventHandler {
         maxMessageLength: MESSAGE_CONTENT_MAX - crmReportContent.length - 2,
       },
     )
-    const sent = await MessageUtils.send(
-      user,
-      `${crmReportContent}\n\n${reportContent}`,
-    )
+    const sent = await MessageUtils.send(user, `${crmReportContent}\n\n${reportContent}`)
     return sent !== null
   }
 

--- a/src/events/voice-state-update-handler.ts
+++ b/src/events/voice-state-update-handler.ts
@@ -11,7 +11,9 @@ import {
   type AttendanceEntry,
   AttendanceService,
   type CrmDisabledReason,
-  formatAttendanceDmContent,
+  formatAttendanceContextText,
+  formatAttendanceRosterCodeBlock,
+  MESSAGE_CONTENT_MAX,
   resolveScheduledEvent,
 } from '../services/attendance-service.js'
 import { type CrmAttendancePayload, type CrmService } from '../services/crm-service.js'
@@ -61,13 +63,15 @@ export class VoiceStateUpdateHandler implements EventHandler {
       //provide arg for custom name
       const eventId = scheduledEvent?.id ?? sessionId
       const displayEventName = customEventName ?? scheduledEvent?.name ?? defaultEventName
+      const finalizedAt = new Date()
 
       if (crmDisabledReason) {
-        await this.sendFallbackDm(
+        await this.sendAttendanceFallbackDms(
           user,
           channelName,
           displayEventName,
           entries,
+          finalizedAt,
           CRM_DISABLED_DM_NOTES[crmDisabledReason],
           null,
         )
@@ -89,14 +93,14 @@ export class VoiceStateUpdateHandler implements EventHandler {
         const response = await this.crmService.recordAttendance(payload)
 
         try {
-          const sent = await MessageUtils.send(
+          const sent = await this.sendCrmSuccessDm(
             user,
-            this.formatCrmReportDm(
-              displayEventName,
-              channelName,
-              response.total_received,
-              response.unlinked_participants,
-            ),
+            displayEventName,
+            channelName,
+            entries,
+            finalizedAt,
+            response.total_received,
+            response.unlinked_participants,
           )
           if (!sent) {
             Logger.warn(
@@ -110,11 +114,12 @@ export class VoiceStateUpdateHandler implements EventHandler {
         }
       } catch (error) {
         Logger.error('CRM record-attendance failed', error)
-        await this.sendFallbackDm(
+        await this.sendAttendanceFallbackDms(
           user,
           channelName,
           displayEventName,
           entries,
+          finalizedAt,
           'Failed to sync attendance to the CRM. The raw payload is below so it can be replayed manually.',
           payload,
         )
@@ -124,21 +129,34 @@ export class VoiceStateUpdateHandler implements EventHandler {
     }
   }
 
-  private async sendFallbackDm(
+  private async sendAttendanceFallbackDms(
     user: User,
     channelName: string,
     meetingSubject: string | undefined,
     entries: AttendanceEntry[],
+    at: Date,
     note: string,
     payload: CrmAttendancePayload | null,
   ): Promise<void> {
-    await MessageUtils.send(user, `:warning: ${note}`)
+    await MessageUtils.send(
+      user,
+      [
+        `:warning: ${note}`,
+        '',
+        formatAttendanceContextText({
+          channelName,
+          meetingSubject,
+          entries,
+          at,
+        }),
+      ].join('\n'),
+    )
 
-    const reportContent = formatAttendanceDmContent({
+    const reportContent = formatAttendanceRosterCodeBlock({
       channelName,
       meetingSubject,
       entries,
-      at: new Date(),
+      at,
     })
 
     await MessageUtils.send(user, reportContent)
@@ -155,9 +173,44 @@ export class VoiceStateUpdateHandler implements EventHandler {
     }
   }
 
-  private formatCrmReportDm(
+  private async sendCrmSuccessDm(
+    user: User,
     eventName: string,
     channelName: string,
+    entries: AttendanceEntry[],
+    at: Date,
+    total: number,
+    unlinked: Array<{ discord_id: string; discord_name: string }>,
+  ): Promise<boolean> {
+    const crmReportContent = this.formatCrmAttendanceSummaryText(
+      eventName,
+      channelName,
+      at,
+      total,
+      unlinked,
+    )
+    const reportContent = formatAttendanceRosterCodeBlock(
+      {
+        channelName,
+        meetingSubject: eventName,
+        entries,
+        at,
+      },
+      {
+        maxMessageLength: MESSAGE_CONTENT_MAX - crmReportContent.length - 2,
+      },
+    )
+    const sent = await MessageUtils.send(
+      user,
+      `${crmReportContent}\n\n${reportContent}`,
+    )
+    return sent !== null
+  }
+
+  private formatCrmAttendanceSummaryText(
+    eventName: string,
+    channelName: string,
+    at: Date,
     total: number,
     unlinked: Array<{ discord_id: string; discord_name: string }>,
   ): string {
@@ -168,7 +221,12 @@ export class VoiceStateUpdateHandler implements EventHandler {
       : '. Go to the CRM to finish the upload into the event.'
     const lines: string[] = [
       '**Attendance staged in CRM** :white_check_mark:',
-      `Event: **${escapeMarkdown(eventName)}** (${escapeMarkdown(channelName)})`,
+      formatAttendanceContextText({
+        channelName,
+        meetingSubject: eventName,
+        entries: [],
+        at,
+      }),
       `All ${total} attendee${plural} recorded${tail}`,
     ]
 

--- a/src/services/attendance-service.ts
+++ b/src/services/attendance-service.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import {
   GuildScheduledEventStatus,
   StageChannel,
+  escapeMarkdown,
   type Guild,
   type GuildBasedChannel,
   type VoiceState,
@@ -23,43 +24,63 @@ export interface AttendanceDmPayload {
   at: Date
 }
 
+interface AttendanceDmFormatOptions {
+  maxMessageLength?: number
+}
+
 function escapeMarkdownCodeFence(text: string): string {
   return text.replaceAll('```', "'''")
 }
 
 /** Plain report text (inside the DM code fence for copy-paste). */
-export function formatAttendanceReportText(payload: AttendanceDmPayload): string {
-  const channelName = escapeMarkdownCodeFence(payload.channelName)
+export function formatAttendanceRosterText(payload: AttendanceDmPayload): string {
+  return formatAttendanceEntriesText(payload.entries)
+}
+
+/** Plain attendance metadata text for the part of a DM outside the code fence. */
+export function formatAttendanceContextText(payload: AttendanceDmPayload): string {
   const dt = DateTime.fromJSDate(payload.at, { zone: 'utc' })
-  const dateStr = dt.toFormat("cccc, LLLL d, yyyy 'at' h:mm a 'UTC'")
-  let text = `# Attendance of ${channelName}\nDate: ${dateStr}\n`
-  if (payload.meetingSubject) {
-    text += `Subject: ${escapeMarkdownCodeFence(payload.meetingSubject)}\n`
-  }
-  text += '\n'
-  if (payload.entries.length === 0) {
-    text += '_No attendees._'
-  } else {
-    text += payload.entries.map((e) => `- ${escapeMarkdownCodeFence(e.displayName)}`).join('\n')
-  }
-  return text
+  const lines = [
+    `Event: **${escapeMarkdown(payload.meetingSubject ?? payload.channelName)}**`,
+    `Channel: ${escapeMarkdown(payload.channelName)}`,
+    `Date: ${dt.toFormat("cccc, LLLL d, yyyy 'at' h:mm a 'UTC'")}`,
+  ]
+  return lines.join('\n')
 }
 
 /** Discord DM / message content max length. */
-const MESSAGE_CONTENT_MAX = 2000
+export const MESSAGE_CONTENT_MAX = 2000
 const CODE_FENCE_OPEN = '```\n'
 const CODE_FENCE_CLOSE = '\n```'
 
 /**
  * DM body: report wrapped in a ``` code block so Discord shows the one-click copy control.
  */
-export function formatAttendanceDmContent(payload: AttendanceDmPayload): string {
-  let report = formatAttendanceReportText(payload)
-  const maxInner = MESSAGE_CONTENT_MAX - CODE_FENCE_OPEN.length - CODE_FENCE_CLOSE.length
+export function formatAttendanceRosterCodeBlock(
+  payload: AttendanceDmPayload,
+  options: AttendanceDmFormatOptions = {},
+): string {
+  const maxMessageLength = options.maxMessageLength ?? MESSAGE_CONTENT_MAX
+  let report = formatAttendanceRosterText(payload)
+  const maxInner = maxMessageLength - CODE_FENCE_OPEN.length - CODE_FENCE_CLOSE.length
+  if (maxInner <= 0) {
+    return `${CODE_FENCE_OPEN}${CODE_FENCE_CLOSE}`
+  }
   if (report.length > maxInner) {
-    report = `${report.slice(0, maxInner - 24)}\n\n(truncated)`
+    const suffix = '\n\n(truncated)'
+    report =
+      maxInner > suffix.length
+        ? `${report.slice(0, maxInner - suffix.length)}${suffix}`
+        : report.slice(0, maxInner)
   }
   return `${CODE_FENCE_OPEN}${report}${CODE_FENCE_CLOSE}`
+}
+
+function formatAttendanceEntriesText(entries: AttendanceEntry[]): string {
+  if (entries.length === 0) {
+    return '_No attendees._'
+  }
+  return entries.map((e) => `- ${escapeMarkdownCodeFence(e.displayName)}`).join('\n')
 }
 
 /**

--- a/src/services/attendance-service.ts
+++ b/src/services/attendance-service.ts
@@ -32,6 +32,13 @@ function escapeMarkdownCodeFence(text: string): string {
   return text.replaceAll('```', "'''")
 }
 
+function formatAttendanceEntriesText(entries: AttendanceEntry[]): string {
+  if (entries.length === 0) {
+    return '_No attendees._'
+  }
+  return entries.map((e) => `- ${escapeMarkdownCodeFence(e.displayName)}`).join('\n')
+}
+
 /** Plain report text (inside the DM code fence for copy-paste). */
 export function formatAttendanceRosterText(payload: AttendanceDmPayload): string {
   return formatAttendanceEntriesText(payload.entries)
@@ -74,13 +81,6 @@ export function formatAttendanceRosterCodeBlock(
         : report.slice(0, maxInner)
   }
   return `${CODE_FENCE_OPEN}${report}${CODE_FENCE_CLOSE}`
-}
-
-function formatAttendanceEntriesText(entries: AttendanceEntry[]): string {
-  if (entries.length === 0) {
-    return '_No attendees._'
-  }
-  return entries.map((e) => `- ${escapeMarkdownCodeFence(e.displayName)}`).join('\n')
 }
 
 /**

--- a/tests/events/voice-state-update-handler.test.ts
+++ b/tests/events/voice-state-update-handler.test.ts
@@ -18,9 +18,8 @@ describe('VoiceStateUpdateHandler', () => {
   })
 
   it('sends the attendee list after successfully staging attendance in the CRM', async () => {
-    const { VoiceStateUpdateHandler } = await import(
-      '../../src/events/voice-state-update-handler.js'
-    )
+    const { VoiceStateUpdateHandler } =
+      await import('../../src/events/voice-state-update-handler.js')
     const user = {} as User
     const guild = {
       scheduledEvents: {
@@ -86,9 +85,8 @@ describe('VoiceStateUpdateHandler', () => {
   })
 
   it('sends event details and a roster-only attendance list when CRM staging fails', async () => {
-    const { VoiceStateUpdateHandler } = await import(
-      '../../src/events/voice-state-update-handler.js'
-    )
+    const { VoiceStateUpdateHandler } =
+      await import('../../src/events/voice-state-update-handler.js')
     const user = {} as User
     const guild = {
       scheduledEvents: {

--- a/tests/events/voice-state-update-handler.test.ts
+++ b/tests/events/voice-state-update-handler.test.ts
@@ -1,0 +1,151 @@
+import { type Client, type User, type VoiceState } from 'discord.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type AttendanceService } from '../../src/services/attendance-service.js'
+import { type CrmService } from '../../src/services/crm-service.js'
+
+const sendMock = vi.hoisted(() => vi.fn(async () => ({})))
+
+vi.mock('../../src/utils/message-utils.js', () => ({
+  MessageUtils: {
+    send: sendMock,
+  },
+}))
+
+describe('VoiceStateUpdateHandler', () => {
+  beforeEach(() => {
+    sendMock.mockClear()
+  })
+
+  it('sends the attendee list after successfully staging attendance in the CRM', async () => {
+    const { VoiceStateUpdateHandler } = await import(
+      '../../src/events/voice-state-update-handler.js'
+    )
+    const user = {} as User
+    const guild = {
+      scheduledEvents: {
+        cache: new Map(),
+        fetch: vi.fn(async () => new Map()),
+      },
+    }
+    const client = {
+      guilds: {
+        fetch: vi.fn(async () => guild),
+      },
+      users: {
+        fetch: vi.fn(async () => user),
+      },
+    } as unknown as Client
+    const attendanceService = {
+      handleVoiceStateUpdate: vi.fn(() => ({
+        userId: 'tracker-1',
+        guildId: 'guild-1',
+        channelId: 'channel-1',
+        channelName: 'Strategy Room',
+        sessionId: 'session-1',
+        defaultEventName: 'Strategy Room - May 11, 2026 10:00 PM UTC',
+        entries: [
+          { id: 'user-1', displayName: 'Ada Lovelace' },
+          { id: 'user-2', displayName: 'Grace Hopper' },
+        ],
+      })),
+    } as unknown as AttendanceService
+    const crmService = {
+      recordAttendance: vi.fn(async () => ({
+        event_id: 'session-1',
+        total_received: 2,
+        unlinked_participants: [],
+      })),
+    } as unknown as CrmService
+
+    const handler = new VoiceStateUpdateHandler(attendanceService, crmService, client)
+
+    await handler.process({} as VoiceState, {} as VoiceState)
+
+    expect(crmService.recordAttendance).toHaveBeenCalledWith({
+      event_id: 'session-1',
+      event_name: 'Strategy Room - May 11, 2026 10:00 PM UTC',
+      event_tracker_discord_id: 'tracker-1',
+      participants: [
+        { discord_id: 'user-1', discord_name: 'Ada Lovelace', status: 'ATTENDED' },
+        { discord_id: 'user-2', discord_name: 'Grace Hopper', status: 'ATTENDED' },
+      ],
+    })
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    const content = sendMock.mock.calls[0]?.[1] as string
+    expect(content).toContain('Attendance staged in CRM')
+    expect(content).toContain('Event: **Strategy Room - May 11, 2026 10:00 PM UTC**')
+    expect(content).toContain('Channel: Strategy Room')
+    expect(content).toContain('Date:')
+    const rosterBlock = content.match(/```\n([\s\S]*)\n```/)?.[1]
+    expect(rosterBlock).not.toContain('# Attendance of Strategy Room')
+    expect(rosterBlock).not.toContain('Date:')
+    expect(rosterBlock).not.toContain('Subject:')
+    expect(rosterBlock).toContain('- Ada Lovelace')
+    expect(rosterBlock).toContain('- Grace Hopper')
+  })
+
+  it('sends event details and a roster-only attendance list when CRM staging fails', async () => {
+    const { VoiceStateUpdateHandler } = await import(
+      '../../src/events/voice-state-update-handler.js'
+    )
+    const user = {} as User
+    const guild = {
+      scheduledEvents: {
+        cache: new Map(),
+        fetch: vi.fn(async () => new Map()),
+      },
+    }
+    const client = {
+      guilds: {
+        fetch: vi.fn(async () => guild),
+      },
+      users: {
+        fetch: vi.fn(async () => user),
+      },
+    } as unknown as Client
+    const attendanceService = {
+      handleVoiceStateUpdate: vi.fn(() => ({
+        userId: 'tracker-1',
+        guildId: 'guild-1',
+        channelId: 'channel-1',
+        channelName: 'Strategy Room',
+        sessionId: 'session-1',
+        defaultEventName: 'Strategy Room - May 11, 2026 10:00 PM UTC',
+        entries: [
+          { id: 'user-1', displayName: 'Ada Lovelace' },
+          { id: 'user-2', displayName: 'Grace Hopper' },
+        ],
+      })),
+    } as unknown as AttendanceService
+    const crmService = {
+      recordAttendance: vi.fn(async () => {
+        throw new Error('CRM unavailable')
+      }),
+    } as unknown as CrmService
+
+    const handler = new VoiceStateUpdateHandler(attendanceService, crmService, client)
+
+    await handler.process({} as VoiceState, {} as VoiceState)
+
+    expect(sendMock).toHaveBeenCalledTimes(3)
+    const warningContent = sendMock.mock.calls[0]?.[1] as string
+    expect(warningContent).toContain('Failed to sync attendance to the CRM')
+    expect(warningContent).toContain('Event: **Strategy Room - May 11, 2026 10:00 PM UTC**')
+    expect(warningContent).toContain('Channel: Strategy Room')
+    expect(warningContent).toContain('Date:')
+
+    const rosterContent = sendMock.mock.calls[1]?.[1] as string
+    const rosterBlock = rosterContent.match(/```\n([\s\S]*)\n```/)?.[1]
+    expect(rosterBlock).not.toContain('# Attendance of Strategy Room')
+    expect(rosterBlock).not.toContain('Date:')
+    expect(rosterBlock).not.toContain('Subject:')
+    expect(rosterBlock).toContain('- Ada Lovelace')
+    expect(rosterBlock).toContain('- Grace Hopper')
+
+    expect(sendMock.mock.calls[2]?.[1]).toMatchObject({
+      content: '**Raw CRM payload (for manual replay):**',
+      files: expect.any(Array),
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Always DM the attendance roster after `/attendance-track` finishes, including when CRM staging succeeds.
- Keep attendance roster code blocks roster-only, with event/channel/date context shown above the copyable roster.
- Add unit coverage for CRM staging success and failure DM behavior.

## DM examples

### `/attendance`

````markdown
Event: **Weekly Call**
Channel: Strategy Room
Date: Monday, May 11, 2026 at 9:20 PM UTC

```
- Ada Lovelace
- Grace Hopper
```
````

### `/attendance-track` with successful CRM staging

````markdown
**Attendance staged in CRM** :white_check_mark:
Event: **Weekly Call**
Channel: Strategy Room
Date: Monday, May 11, 2026 at 9:20 PM UTC
All 2 attendees recorded. Go to the CRM to finish the upload into the event.

```
- Ada Lovelace
- Grace Hopper
```
````

### `/attendance-track` with successful CRM staging and unlinked participants

````markdown
**Attendance staged in CRM** :white_check_mark:
Event: **Weekly Call**
Channel: Strategy Room
Date: Monday, May 11, 2026 at 9:20 PM UTC
All 3 attendees recorded. Go to the CRM to finish the upload into the event.

:warning: **Need a CRM contact before they can be uploaded (1):**
- Unlinked User

```
- Ada Lovelace
- Grace Hopper
- Unlinked User
```
````

### `/attendance-track` when CRM sync is disabled at start

````markdown
:warning: You weren't authorized to record CRM attendance, so this list wasn't synced — keep it for your records.

Event: **Weekly Call**
Channel: Strategy Room
Date: Monday, May 11, 2026 at 9:20 PM UTC
````

followed by:

````markdown
```
- Ada Lovelace
- Grace Hopper
```
````

The warning text varies for an unlinked Discord account or a CRM permission check failure.

### `/attendance-track` when CRM staging fails at the end

````markdown
:warning: Failed to sync attendance to the CRM. The raw payload is below so it can be replayed manually.

Event: **Weekly Call**
Channel: Strategy Room
Date: Monday, May 11, 2026 at 9:20 PM UTC
````

followed by:

````markdown
```
- Ada Lovelace
- Grace Hopper
```
````

followed by a raw CRM payload JSON attachment for manual replay.
