### PR TITLE
Look up welcome roles by ID instead of name

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -106,8 +106,6 @@
   },
   "welcomeThread": {
     "channelName": "entrance",
-    "welcomeTeamRoleName": "Welcome Team",
-    "welcomeSupervisorsRoleName": "Welcome Supervisors",
     "maxActiveThreads": 50,
     "maxWelcomeTeamMembers": 4,
     "inactivityDays": 2
@@ -151,6 +149,14 @@
     "ADMIN": {
       "id": "1347656064900005970",
       "name": "Admin"
+    },
+    "WELCOME_TEAM": {
+      "id": "1459295527886651595",
+      "name": "Welcome Team"
+    },
+    "WELCOME_SUPERVISOR": {
+      "id": "1482565506945777735",
+      "name": "Welcome Supervisors"
     }
   }
 }

--- a/src/constants/server-roles.ts
+++ b/src/constants/server-roles.ts
@@ -7,7 +7,14 @@ export interface ServerRole {
   name: string
 }
 
-export type RoleKey = 'COORDINATOR' | 'TEAM_LEAD' | 'ORGANIZER' | 'DIRECTOR' | 'ADMIN'
+export type RoleKey =
+  | 'COORDINATOR'
+  | 'TEAM_LEAD'
+  | 'ORGANIZER'
+  | 'DIRECTOR'
+  | 'ADMIN'
+  | 'WELCOME_TEAM'
+  | 'WELCOME_SUPERVISOR'
 
 export const ServerRoles: Record<RoleKey, ServerRole> = Config.roles
 

--- a/src/services/welcome-thread-service.ts
+++ b/src/services/welcome-thread-service.ts
@@ -7,6 +7,7 @@ import {
 } from 'discord.js'
 import { createRequire } from 'node:module'
 
+import { ServerRoles } from '../constants/server-roles.js'
 import { Logger } from './logger.js'
 
 const require = createRequire(import.meta.url)
@@ -14,8 +15,6 @@ const Config = require('../../config/config.json')
 
 interface WelcomeThreadConfig {
   channelName: string
-  welcomeTeamRoleName: string
-  welcomeSupervisorsRoleName: string
   maxActiveThreads: number
   maxTotalThreads: number
   maxWelcomeTeamMembers: number
@@ -33,8 +32,6 @@ export class WelcomeThreadService {
     if (!wt?.channelName) return null
     return {
       channelName: wt.channelName,
-      welcomeTeamRoleName: wt.welcomeTeamRoleName ?? 'Welcome Team',
-      welcomeSupervisorsRoleName: wt.welcomeSupervisorsRoleName ?? 'Welcome Supervisors',
       maxActiveThreads: Math.max(1, Number(wt.maxActiveThreads) || 50),
       maxTotalThreads: Math.max(1, Number(wt.maxTotalThreads) || 500),
       maxWelcomeTeamMembers: Math.max(1, Number(wt.maxWelcomeTeamMembers) || 4),
@@ -250,10 +247,19 @@ export class WelcomeThreadService {
       return null
     }
 
-    const welcomeRole = member.guild.roles.cache.find((r) => r.name === config.welcomeTeamRoleName)
-    const welcomeSupervisorsRole = member.guild.roles.cache.find(
-      (r) => r.name === config.welcomeSupervisorsRoleName,
-    )
+    const welcomeRole = member.guild.roles.cache.get(ServerRoles.WELCOME_TEAM.id)
+    const welcomeSupervisorsRole = member.guild.roles.cache.get(ServerRoles.WELCOME_SUPERVISOR.id)
+
+    if (!welcomeRole) {
+      Logger.warn(
+        `Welcome Team role (id: ${ServerRoles.WELCOME_TEAM.id}) not found in ${member.guild.name}; no welcome team members will be added`,
+      )
+    }
+    if (!welcomeSupervisorsRole) {
+      Logger.warn(
+        `Welcome Supervisor role (id: ${ServerRoles.WELCOME_SUPERVISOR.id}) not found in ${member.guild.name}; no welcome supervisors will be added`,
+      )
+    }
 
     const membersToAdd = new Set<string>()
     const allMembers = await member.guild.members.fetch({ withPresences: true })


### PR DESCRIPTION
Closes #89

# Description

Add Welcome Team/supervisor to roles config with name/id. Point welcome bot behavior to new roles instead of hard coded names in the welcome config.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested? IMPORTANT

- Manual testing on local with test Discord bot. No unit tests created since it would be tautological

**Test Configuration**:

- Local override to welcome team id. test that name does not matter and only the id matters in the role.

# Checklist:

- [x] I have performed a self-review of my own code, especially if LLM generated
- [x] LLM generated commit history did not generate the code

No unit tests added due to tautological nature of config changes.
