### PR TITLE
Push SQLite schema on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,9 @@ RUN npm run build
 # Expose ports
 EXPOSE 3001
 
-# Run the application
-CMD [ "node", "dist/start-manager.js" ]
+# Push the database schema against the runtime-mounted SQLite file, then start the app.
+CMD if [ -n "$SQLITE_PATH" ]; then \
+      mkdir -p "$(dirname "$SQLITE_PATH")" && \
+      DRIZZLE_STRICT=false npm run db:push; \
+    fi; \
+    exec node --enable-source-maps dist/start-manager.js

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ To mirror Discord scheduled events from **DGG Political Action** into the DGG gr
 
 The bot lists Google Calendar events in a fixed time window and compares them to Discord scheduled events. Discord is the source of truth: each new Google event’s description includes the Discord scheduled event id so the next run can tell what is already synced—no separate state file on disk.
 
+### Optional: SQLite-backed commands
+
+`/link-account`, `/grant-access`, and runtime content edits use SQLite when
+`SQLITE_PATH` is set. In Docker/Coolify, prefer an absolute path:
+
+```bash
+SQLITE_PATH=/app/db/dggbot.sqlite
+```
+
+Persist the whole `/app/db` directory, not only `/app/db/dggbot.sqlite`. The
+app enables SQLite WAL mode, which creates adjacent `-wal` and `-shm` files
+that must live on persistent storage with the main database file. The Docker
+startup command runs `npm run db:push` when `SQLITE_PATH` is set, so schema
+changes are applied to the mounted runtime database before the bot starts.
+
 ### Not used
 
 Clustering Configuration (only needed if clustering.enabled is true), we will likely never cluster because it's for bots that serve 2,500+ guilds.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   dbCredentials: {
     url: process.env.SQLITE_PATH,
   },
-  strict: true,
+  strict: process.env.DRIZZLE_STRICT !== 'false',
   verbose: true,
 })

--- a/src/database/client.ts
+++ b/src/database/client.ts
@@ -1,14 +1,24 @@
 import Sqlite from 'better-sqlite3'
 import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3'
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
 
 import * as schema from './schema.js'
 
 export type Database = BetterSQLite3Database<typeof schema>
 
+function ensureDatabaseDirectory(filename: string): void {
+  if (filename === ':memory:' || filename.startsWith('file:')) {
+    return
+  }
+  mkdirSync(dirname(filename), { recursive: true })
+}
+
 export function createDatabase(filename = process.env.SQLITE_PATH): Database {
   if (!filename) {
     throw new Error('SQLITE_PATH is not set')
   }
+  ensureDatabaseDirectory(filename)
   const sqlite = new Sqlite(filename)
   sqlite.pragma('journal_mode = WAL')
   sqlite.pragma('foreign_keys = ON')

--- a/tests/helpers/test-database.ts
+++ b/tests/helpers/test-database.ts
@@ -5,19 +5,42 @@ import * as schema from '../../src/database/schema.js'
 
 export type TestDatabase = ReturnType<typeof drizzle<typeof schema>>
 
-/** In-memory database with the content_override table (mirrors `npm run db:push`). */
+/** In-memory database mirroring the schema created by `npm run db:push`. */
 export function createTestDatabase(): TestDatabase {
   const sqlite = new Sqlite(':memory:')
   sqlite.exec(`
-    CREATE TABLE content_override (
-      id integer PRIMARY KEY AUTOINCREMENT,
-      key text NOT NULL,
-      field text NOT NULL,
-      value text NOT NULL,
-      updated_by text NOT NULL,
-      updated_at integer NOT NULL DEFAULT (unixepoch())
+    CREATE TABLE "user" (
+      "discord_user_id" text PRIMARY KEY,
+      "created_at" integer NOT NULL DEFAULT (unixepoch()),
+      "updated_at" integer NOT NULL DEFAULT (unixepoch())
     );
-    CREATE UNIQUE INDEX content_override_key_field_uq ON content_override (key, field);
+
+    CREATE TABLE "linked_account" (
+      "id" integer PRIMARY KEY AUTOINCREMENT,
+      "discord_user_id" text NOT NULL,
+      "provider" text NOT NULL,
+      "external_id" text NOT NULL,
+      "email" text,
+      "display_name" text,
+      "linked_at" integer NOT NULL DEFAULT (unixepoch()),
+      "updated_at" integer NOT NULL DEFAULT (unixepoch()),
+      FOREIGN KEY ("discord_user_id") REFERENCES "user" ("discord_user_id") ON DELETE cascade
+    );
+    CREATE UNIQUE INDEX "linked_account_user_provider_uq"
+      ON "linked_account" ("discord_user_id", "provider");
+    CREATE UNIQUE INDEX "linked_account_provider_external_uq"
+      ON "linked_account" ("provider", "external_id");
+
+    CREATE TABLE "content_override" (
+      "id" integer PRIMARY KEY AUTOINCREMENT,
+      "key" text NOT NULL,
+      "field" text NOT NULL,
+      "value" text NOT NULL,
+      "updated_by" text NOT NULL,
+      "updated_at" integer NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE UNIQUE INDEX "content_override_key_field_uq"
+      ON "content_override" ("key", "field");
   `)
   return drizzle(sqlite, { schema })
 }


### PR DESCRIPTION
## Summary

- Runs `npm run db:push` during Docker container startup when `SQLITE_PATH` is configured, so schema changes apply to the runtime-mounted SQLite database before the bot starts.
- Allows Docker startup to set `DRIZZLE_STRICT=false` for non-interactive schema pushes without changing the default strict local workflow.
- Ensures the SQLite parent directory exists before opening the database and expands test DB setup to mirror the current schema.
- Documents the recommended Coolify SQLite path and the need to persist the whole `/app/db` directory for WAL files.

## Context

Redeploys can start with a mounted SQLite file that does not have the current schema, which breaks `/content edit` with `no such table: content_override` and also prevents `/link-account` from using its linked account tables. Running the schema push at container startup targets the mounted runtime database instead of the image build filesystem.
