### PR TITLE
Align Docker Node version handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Important entry points:
 
 ## Local Setup
 
-- Use the pinned Node version: `nvm use` (`.nvmrc` currently pins `24.15.0`).
+- Use the pinned Node version: `nvm use` (the exact version lives in `.nvmrc`).
 - Install dependencies with `npm ci` for normal development. Use `npm install` only when intentionally changing dependencies.
 - Local config can be initialized with `npm run copyconfig`.
 - Do not commit secrets from `.env`, local config, service account keys, or generated database files.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM node:22.12
+FROM node:24
 
 # Create app directory
 WORKDIR /app
 
-# Copy package.json and package-lock.json
-COPY package*.json ./
+# Copy package metadata and the shared Node version check.
+COPY .nvmrc package*.json ./
+COPY scripts/check-node-version.mjs scripts/check-node-version.mjs
 
 # Install packages
-RUN npm install
+RUN npm run check-node-version -- --major && NODE_VERSION_CHECK=major npm ci
 
 # Copy the app code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY .nvmrc package*.json ./
 COPY scripts/check-node-version.mjs scripts/check-node-version.mjs
 
 # Install packages
-RUN npm run check-node-version -- --major && NODE_VERSION_CHECK=major npm ci
+RUN NODE_VERSION_CHECK=major npm ci
 
 # Copy the app code
 COPY . .

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ This template for a Discord bot was based upon this public template. https://git
      - It may take up to an hour for command changes to appear.
 5. `npm start`
 
+Docker builds use the cached Node major-version image and verify that it matches
+the major version pinned in `.nvmrc`:
+
+```
+npm run docker:build
+```
+
 ## Contributing With Low Lockfile Noise
 
 When contributors use different Node/npm versions, `package-lock.json` often churns (including platform/libc metadata). To reduce noise:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "dggac-bot",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@discordjs/rest": "^2.5.1",
@@ -52,9 +53,6 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.35.1",
         "vitest": "^3.2.4"
-      },
-      "engines": {
-        "node": "24.15.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "description": "A discord.js bot for DGGAC discord server",
   "license": "MIT",
   "private": true,
-  "engines": {
-    "node": "24.15.0"
-  },
   "type": "module",
   "exports": [
     "./dist/start-bot.js",
@@ -20,7 +17,10 @@
     "format:fix": "prettier --write .",
     "clean": "git clean -xdf --exclude=\"/config/**/*\"",
     "clean:dry": "git clean -xdf --exclude=\"/config/**/*\" --dry-run",
+    "check-node-version": "node scripts/check-node-version.mjs",
     "build": "tsc --project tsconfig.json",
+    "docker:build": "docker build .",
+    "preinstall": "node scripts/check-node-version.mjs",
     "commands:view": "npm run build && node --enable-source-maps dist/start-bot.js commands view",
     "commands:register": "npm run build && node --enable-source-maps dist/start-bot.js commands register",
     "commands:rename": "npm run build && node --enable-source-maps dist/start-bot.js commands rename",

--- a/scripts/check-node-version.mjs
+++ b/scripts/check-node-version.mjs
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const expectedVersion = readFileSync(resolve(rootDirectory, '.nvmrc'), 'utf8').trim()
+const actualVersion = process.version.replace(/^v/, '')
+const checkMajorOnly =
+  process.argv.includes('--major') || process.env.NODE_VERSION_CHECK === 'major'
+
+if (!expectedVersion) {
+  console.error('Expected .nvmrc to contain a Node version.')
+  process.exit(1)
+}
+
+if (checkMajorOnly) {
+  const expectedMajor = expectedVersion.split('.')[0]
+  const actualMajor = actualVersion.split('.')[0]
+
+  if (actualMajor !== expectedMajor) {
+    console.error(
+      `Expected Node major version ${expectedMajor} from .nvmrc, but running ${actualVersion}.`,
+    )
+    process.exit(1)
+  }
+} else if (actualVersion !== expectedVersion) {
+  console.error(
+    `Expected Node ${expectedVersion} from .nvmrc, but running ${actualVersion}. Run \`nvm use\` before installing dependencies.`,
+  )
+  process.exit(1)
+}

--- a/scripts/check-node-version.mjs
+++ b/scripts/check-node-version.mjs
@@ -1,9 +1,13 @@
+/* global console, process */
+
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const rootDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '..')
-const expectedVersion = readFileSync(resolve(rootDirectory, '.nvmrc'), 'utf8').trim()
+const expectedVersion = readFileSync(resolve(rootDirectory, '.nvmrc'), 'utf8')
+  .trim()
+  .replace(/^v/, '')
 const actualVersion = process.version.replace(/^v/, '')
 const checkMajorOnly =
   process.argv.includes('--major') || process.env.NODE_VERSION_CHECK === 'major'


### PR DESCRIPTION
## Summary

- Align the Docker runtime with the repo's Node 24 policy using the cached `node:24` image.
- Add a small `.nvmrc`-based Node version guard: exact matching for local installs, major-version matching in Docker.
- Remove the duplicated exact Node version from package metadata and update docs to point at `.nvmrc`.

## Context

Fixes #110. The Dockerfile had drifted from `.nvmrc` and `package.json`; this keeps Docker on the same major version without requiring a repeated exact patch version in the Dockerfile.
