### PR TITLE
Sanitize CRM Cloudflare response errors

### DIFF
--- a/src/services/crm-service.ts
+++ b/src/services/crm-service.ts
@@ -2,8 +2,15 @@ import fetch, { type RequestInit } from 'node-fetch'
 import { URL } from 'node:url'
 
 const REQUEST_TIMEOUT_MS = 10_000
+const RESPONSE_BODY_PREVIEW_CHARS = 500
 const RECORD_ATTENDANCE_PATH = '/api/discord/staged-event-participations/'
 const CAN_RECORD_ATTENDANCE_PATH = '/api/discord/can-record-attendance/'
+const CLOUDFLARE_CHALLENGE_MARKERS = [
+  'Just a moment...',
+  'Enable JavaScript and cookies to continue',
+  'window._cf_chl_opt',
+  '/cdn-cgi/challenge-platform/',
+] as const
 
 export interface CrmAttendancePayload {
   event_id: string
@@ -35,6 +42,65 @@ export type AttendancePermissionReason =
 export interface CrmAttendancePermissionResponse {
   authorized: boolean
   reason: AttendancePermissionReason
+}
+
+type CrmResponseFailureReason = 'http_status' | 'invalid_json'
+
+interface CrmResponseErrorOptions {
+  label: string
+  status: number
+  statusText: string
+  contentType: string | null
+  body: string
+  reason: CrmResponseFailureReason
+}
+
+function summarizeBody(body: string): string {
+  const normalized = body.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= RESPONSE_BODY_PREVIEW_CHARS) {
+    return normalized
+  }
+
+  return `${normalized.slice(0, RESPONSE_BODY_PREVIEW_CHARS)}...`
+}
+
+function isCloudflareChallengeResponse(body: string): boolean {
+  return CLOUDFLARE_CHALLENGE_MARKERS.some((marker) => body.includes(marker))
+}
+
+export class CrmResponseError extends Error {
+  public readonly label: string
+  public readonly status: number
+  public readonly statusText: string
+  public readonly contentType: string | null
+  public readonly bodyPreview: string
+  public readonly isCloudflareChallenge: boolean
+
+  constructor(options: CrmResponseErrorOptions) {
+    const bodyPreview = summarizeBody(options.body)
+    const isCloudflareChallenge = isCloudflareChallengeResponse(options.body)
+    const statusDescription = options.statusText
+      ? `${options.status} ${options.statusText}`
+      : `${options.status}`
+    const failureDescription =
+      options.reason === 'invalid_json' ? 'returned invalid JSON' : 'failed'
+    const contentTypeDescription = options.contentType
+      ? `; content-type ${options.contentType}`
+      : ''
+    const bodyDescription = bodyPreview ? `; response body preview: ${bodyPreview}` : ''
+    const message = isCloudflareChallenge
+      ? `CRM ${options.label} ${failureDescription}: ${statusDescription} (Cloudflare challenge). Configure Cloudflare to bypass browser challenges for this Discord API route, or set CRM_API_URL to an unchallenged internal/origin URL.`
+      : `CRM ${options.label} ${failureDescription}: ${statusDescription}${contentTypeDescription}${bodyDescription}`
+
+    super(message)
+    this.name = 'CrmResponseError'
+    this.label = options.label
+    this.status = options.status
+    this.statusText = options.statusText
+    this.contentType = options.contentType
+    this.bodyPreview = isCloudflareChallenge ? '[Cloudflare challenge page omitted]' : bodyPreview
+    this.isCloudflareChallenge = isCloudflareChallenge
+  }
 }
 
 export class CrmService {
@@ -93,10 +159,29 @@ export class CrmService {
 
       if (!res.ok) {
         const text = await res.text().catch(() => '')
-        throw new Error(`CRM ${label} failed: ${res.status} ${text}`)
+        throw new CrmResponseError({
+          label,
+          status: res.status,
+          statusText: res.statusText,
+          contentType: res.headers.get('content-type'),
+          body: text,
+          reason: 'http_status',
+        })
       }
 
-      return (await res.json()) as T
+      const text = await res.text()
+      try {
+        return JSON.parse(text) as T
+      } catch {
+        throw new CrmResponseError({
+          label,
+          status: res.status,
+          statusText: res.statusText,
+          contentType: res.headers.get('content-type'),
+          body: text,
+          reason: 'invalid_json',
+        })
+      }
     } finally {
       clearTimeout(timer)
     }

--- a/tests/services/crm-service.test.ts
+++ b/tests/services/crm-service.test.ts
@@ -1,0 +1,122 @@
+import { type RequestInit, Response } from 'node-fetch'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type FetchMock = (url: string, init?: RequestInit) => Promise<Response>
+
+const fetchMock = vi.hoisted(() => vi.fn<FetchMock>())
+
+vi.mock('node-fetch', async () => {
+  const actual = await vi.importActual<typeof import('node-fetch')>('node-fetch')
+  return {
+    ...actual,
+    default: fetchMock,
+  }
+})
+
+const CLOUDFLARE_CHALLENGE_HTML = `
+  <!doctype html>
+  <html>
+    <head><title>Just a moment...</title></head>
+    <body>
+      <p>Enable JavaScript and cookies to continue</p>
+      <script>window._cf_chl_opt = { cType: 'managed' }</script>
+    </body>
+  </html>
+`
+
+describe('CrmService', () => {
+  beforeEach(() => {
+    process.env.CRM_API_URL = 'https://crm.example.test'
+    process.env.CRM_API_TOKEN = 'test-crm-token'
+    fetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    delete process.env.CRM_API_URL
+    delete process.env.CRM_API_TOKEN
+  })
+
+  it('checks attendance permission with token auth and discord id query', async () => {
+    const { CrmService } = await import('../../src/services/crm-service.js')
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ authorized: true, reason: 'ok' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const service = new CrmService()
+    await expect(service.checkAttendancePermission('210253676080660481')).resolves.toEqual({
+      authorized: true,
+      reason: 'ok',
+    })
+
+    const call = fetchMock.mock.calls[0]
+    expect(call).toBeDefined()
+    const [url, init] = call!
+    expect(url).toBe(
+      'https://crm.example.test/api/discord/can-record-attendance/?discord_id=210253676080660481',
+    )
+    expect(init?.method).toBe('get')
+    expect(init?.headers).toEqual(
+      expect.objectContaining({
+        Accept: 'application/json',
+        Authorization: 'Token test-crm-token',
+      }),
+    )
+  })
+
+  it('omits Cloudflare challenge HTML from failed response errors', async () => {
+    const { CrmResponseError, CrmService } = await import('../../src/services/crm-service.js')
+    fetchMock.mockResolvedValue(
+      new Response(CLOUDFLARE_CHALLENGE_HTML, {
+        status: 403,
+        statusText: 'Forbidden',
+        headers: { 'content-type': 'text/html; charset=UTF-8' },
+      }),
+    )
+
+    const service = new CrmService()
+    let caught: unknown
+    try {
+      await service.checkAttendancePermission('210253676080660481')
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(CrmResponseError)
+    const error = caught as InstanceType<typeof CrmResponseError>
+    expect(error.message).toContain('CRM can-record-attendance failed: 403 Forbidden')
+    expect(error.message).toContain('Cloudflare challenge')
+    expect(error.message).toContain('CRM_API_URL')
+    expect(error.message).not.toContain('window._cf_chl_opt')
+    expect(error.message).not.toContain('Enable JavaScript and cookies')
+    expect(error.bodyPreview).toBe('[Cloudflare challenge page omitted]')
+    expect(error.isCloudflareChallenge).toBe(true)
+  })
+
+  it('classifies Cloudflare challenge HTML returned with a success status as invalid JSON', async () => {
+    const { CrmResponseError, CrmService } = await import('../../src/services/crm-service.js')
+    fetchMock.mockResolvedValue(
+      new Response(CLOUDFLARE_CHALLENGE_HTML, {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'content-type': 'text/html; charset=UTF-8' },
+      }),
+    )
+
+    const service = new CrmService()
+    let caught: unknown
+    try {
+      await service.checkAttendancePermission('210253676080660481')
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(CrmResponseError)
+    const error = caught as InstanceType<typeof CrmResponseError>
+    expect(error.message).toContain('CRM can-record-attendance returned invalid JSON: 200 OK')
+    expect(error.message).toContain('Cloudflare challenge')
+    expect(error.bodyPreview).toBe('[Cloudflare challenge page omitted]')
+  })
+})


### PR DESCRIPTION
## Summary

Sanitize CRM HTTP response errors so Cloudflare managed challenge pages do not get dumped into bot logs.

The CRM client now classifies response failures with `CrmResponseError`, trims ordinary response previews, and replaces detected Cloudflare challenge HTML with an actionable message pointing to a Cloudflare bypass rule or an unchallenged `CRM_API_URL`.

## Root Cause

The `/attendance-track` permission preflight receives a Cloudflare browser challenge from the CRM host. The bot correctly disables CRM sync for that tracking session, but the thrown error previously included the full HTML/JavaScript challenge response, making logs noisy and hard to read.

## Impact

Operators will see a short, explicit Cloudflare challenge error instead of the challenge page payload. Normal CRM behavior and the conservative fallback for failed permission checks are unchanged.

Tests were added for the successful permission check path, Cloudflare `403` responses, and challenge HTML returned with a successful HTTP status.
