### PR TITLE
Add Coolify health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ RUN npm run build
 # Expose ports
 EXPOSE 3001
 
+# Let Coolify verify that the manager API is accepting requests.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5m --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3001/health').then((response) => { if (!response.ok) process.exit(1) }).catch(() => process.exit(1))"
+
 # Push the database schema against the runtime-mounted SQLite file, then start the app.
 CMD if [ -n "$SQLITE_PATH" ]; then \
       mkdir -p "$(dirname "$SQLITE_PATH")" && \

--- a/src/controllers/root-controller.ts
+++ b/src/controllers/root-controller.ts
@@ -8,9 +8,14 @@ export class RootController implements Controller {
 
   public register(): void {
     this.router.get('/', (req, res) => this.get(req, res))
+    this.router.get('/health', (_req, res) => this.getHealth(res))
   }
 
   private async get(req: Request, res: Response): Promise<void> {
     res.status(200).json({ name: 'Discord Bot Cluster API', author: 'DGGPA' })
+  }
+
+  private getHealth(res: Response): void {
+    res.status(200).json({ status: 'ok' })
   }
 }

--- a/tests/controllers/root-controller.test.ts
+++ b/tests/controllers/root-controller.test.ts
@@ -1,0 +1,20 @@
+import { type Express } from 'express'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+
+import { RootController } from '../../src/controllers/root-controller.js'
+import { Api } from '../../src/models/api.js'
+
+function buildApp(): Express {
+  const api = new Api([new RootController()])
+  return api.app
+}
+
+describe('RootController', () => {
+  it('reports a successful health check', async () => {
+    const res = await request(buildApp()).get('/health')
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ status: 'ok' })
+  })
+})


### PR DESCRIPTION
## Summary

- add an unauthenticated `GET /health` endpoint on the manager API
- add a Docker `HEALTHCHECK` that probes the endpoint on port 3001
- add focused controller coverage for the health response

## Why

Coolify needs a deterministic container health signal instead of inferring
readiness from the process remaining alive. The manager API starts after
Discord shard startup, so this probe reports healthy once the application is
ready to accept API requests.

## Impact

Deployments can use the image's built-in health check without adding runtime
packages such as curl. The endpoint returns a stable HTTP 200 response with
`{ "status": "ok" }`.
