### PR TITLE
Allow autofix bot to trigger Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,6 +29,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_CODE_REVIEW }}
+          allowed_bots: "autofix-ci[bot]"
           track_progress: true
           show_full_output: true
           prompt: |


### PR DESCRIPTION
## Summary

Allow `autofix-ci[bot]` to trigger the Claude Code review action.

## Why

Autofix commits trigger a new `pull_request.synchronize` event. The resulting Claude review was rejected because the action blocks bot actors by default, leaving PRs without a review of the final autofixed commit.

## Change

Add an explicit `allowed_bots` entry for `autofix-ci[bot]` while keeping concurrency cancellation enabled.

## Validation

- `git diff --check`