### PR TITLE
Normalize autofix bot workflow formatting

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,7 +29,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_CODE_REVIEW }}
-          allowed_bots: "autofix-ci[bot]"
+          allowed_bots: 'autofix-ci[bot]'
           track_progress: true
           show_full_output: true
           prompt: |


### PR DESCRIPTION
## Summary

- Normalize the `allowed_bots` value quoting in the Claude review workflow.
- Keep the workflow formatting consistent with the repository’s Prettier configuration.

## Validation

- `npm ci`
- `npm run format:fix`
- `npm run lint:fix` (completed with two existing unused-import warnings and no errors)
- `git diff --check`