### PR TITLE
Trigger Claude reviews from PR comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,52 +2,65 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
     branches: [dev]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   claude-review:
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: write
       id-token: write
+      actions: read
 
     steps:
+      - name: Check target branch
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          base_ref=$(gh pr view "$PR_NUMBER" --json baseRefName --jq '.baseRefName')
+          if [ "$base_ref" = "dev" ]; then
+            echo "is_target=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_target=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Run Claude Code Review
+        if: steps.target.outputs.is_target == 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_CODE_REVIEW }}
           allowed_bots: 'autofix-ci[bot]'
+          trigger_phrase: '@claude'
           track_progress: true
           show_full_output: true
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Perform a general code review for this Node 24, TypeScript ESM Discord bot built with
-            discord.js. Look for high-signal, actionable issues introduced by this PR, including
-            correctness bugs, security vulnerabilities, Discord permission or authorization mistakes,
-            interaction lifecycle errors, data leaks, unsafe Drizzle/SQLite access, shard or scheduled
-            job problems, Discord API and external integration failures, command metadata or localization
-            mismatches, missing or weak tests for changed behavior, performance regressions,
-            maintainability problems, and clear AGENTS.md violations.
-
-            Review only issues introduced by this PR. Do not flag pre-existing code unless the PR makes it worse.
-            Prefer inline comments for specific code issues. Include a top-level summary comment when the review is complete.
-            If no issues are found, post a top-level comment saying no high-signal issues were found.
-
+          prompt: ${{ github.event_name == 'pull_request' && 'Review this pull request using the review criteria in the system prompt.' || '' }}
           claude_args: |
             --model claude-opus-5
+            --system-prompt "Perform a general code review for this Node 24, TypeScript ESM Discord bot built with discord.js. Look for high-signal, actionable issues introduced by this PR, including correctness bugs, security vulnerabilities, Discord permission or authorization mistakes, interaction lifecycle errors, data leaks, unsafe Drizzle/SQLite access, shard or scheduled job problems, Discord API and external integration failures, command metadata or localization mismatches, missing or weak tests for changed behavior, performance regressions, maintainability problems, and clear AGENTS.md violations. Review only issues introduced by this PR. Do not flag pre-existing code unless the PR makes it worse. Prefer inline comments for specific code issues. Include a top-level summary comment when the review is complete. If no issues are found, post a top-level comment saying no high-signal issues were found."
             --allowedTools "Read,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git show:*),Bash(rg:*),Bash(sed:*),Bash(nl:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,6 +31,11 @@ jobs:
       actions: read
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - name: Check target branch
         id: target
         env:
@@ -43,11 +48,6 @@ jobs:
           else
             echo "is_target=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
 
       - name: Run Claude Code Review
         if: steps.target.outputs.is_target == 'true'


### PR DESCRIPTION
## What changed

- Trigger Claude automatically when a PR targeting `dev` is opened.
- Trigger Claude from `@claude` in PR comments, inline review comments, and submitted reviews.
- Preserve native Claude mention mode for comment-driven reviews.
- Keep the existing repository-specific review criteria and `dev` branch restriction.
- Add CI read permission and update checkout to the pinned v6 action.

## Validation

- Prettier check passed for the workflow.
- `git diff --check` passed.

No application code or tests were changed.