### PR TITLE
Prevent overlapping executions of scheduled jobs

### DIFF
--- a/lang/logs.json
+++ b/lang/logs.json
@@ -31,7 +31,7 @@
   },
   "warn": {
     "managerNoShards": "No shards to spawn.",
-    "jobSkipped": "Skipped job '{JOB}' because its previous run is still active."
+    "jobSkipped": "Skipped job '{JOB}' because its previous run has been active for {DURATION_SECONDS} seconds."
   },
   "error": {
     "unspecified": "An unspecified error occurred.",
@@ -46,6 +46,8 @@
     "clientLogin": "An error occurred while the client attempted to login.",
     "botReady": "An error occurred while running the onBotReady callback.",
     "job": "An error occurred while running the '{JOB}' job.",
+    "jobSchedule": "Could not schedule job '{JOB}' for '{SCHEDULE}'.",
+    "jobStuck": "Job '{JOB}' has been active for {DURATION_SECONDS} seconds and is still blocking scheduled runs.",
     "updatedServerCountSite": "An error occurred while updating the server count on '{BOT_SITE}'.",
     "guildJoin": "An error occurred while processing a guild join.",
     "guildLeave": "An error occurred while processing a guild leave.",

--- a/lang/logs.json
+++ b/lang/logs.json
@@ -30,7 +30,8 @@
     "calendarSyncDeleted": "Calendar sync: removed '{EVENT_NAME}' from Google Calendar."
   },
   "warn": {
-    "managerNoShards": "No shards to spawn."
+    "managerNoShards": "No shards to spawn.",
+    "jobSkipped": "Skipped job '{JOB}' because its previous run is still active."
   },
   "error": {
     "unspecified": "An unspecified error occurred.",

--- a/src/services/job-service.ts
+++ b/src/services/job-service.ts
@@ -1,7 +1,6 @@
 import { CronExpressionParser } from 'cron-parser'
 import { DateTime } from 'luxon'
-import schedule from 'node-schedule'
-import { type Job as ScheduledJob } from 'node-schedule'
+import schedule, { type Job as ScheduledJob } from 'node-schedule'
 import { createRequire } from 'node:module'
 
 import { Logger } from './index.js'
@@ -11,7 +10,9 @@ const require = createRequire(import.meta.url)
 const Logs = require('../../lang/logs.json')
 
 export class JobService {
-  private inFlightJobs = new Set<Job>()
+  private static readonly stuckJobThresholdMs = 60 * 60 * 1000
+
+  private inFlightJobs = new Map<Job, { startedAt: number; stuckReported: boolean }>()
   private scheduledJobs: ScheduledJob[] = []
   private started = false
 
@@ -37,12 +38,30 @@ export class JobService {
           }
 
       const scheduledJob = schedule.scheduleJob(jobSchedule, async () => {
-        if (this.inFlightJobs.has(job)) {
-          Logger.warn(Logs.warn.jobSkipped.replaceAll('{JOB}', job.name))
+        const inFlightJob = this.inFlightJobs.get(job)
+        if (inFlightJob) {
+          const elapsedMs = Math.max(0, Date.now() - inFlightJob.startedAt)
+          const elapsedSeconds = Math.floor(elapsedMs / 1000).toString()
+
+          if (elapsedMs >= JobService.stuckJobThresholdMs && !inFlightJob.stuckReported) {
+            inFlightJob.stuckReported = true
+            Logger.error(
+              Logs.error.jobStuck
+                .replaceAll('{JOB}', job.name)
+                .replaceAll('{DURATION_SECONDS}', elapsedSeconds),
+            )
+          } else {
+            Logger.warn(
+              Logs.warn.jobSkipped
+                .replaceAll('{JOB}', job.name)
+                .replaceAll('{DURATION_SECONDS}', elapsedSeconds),
+            )
+          }
+
           return
         }
 
-        this.inFlightJobs.add(job)
+        this.inFlightJobs.set(job, { startedAt: Date.now(), stuckReported: false })
 
         try {
           if (job.log) {
@@ -60,6 +79,16 @@ export class JobService {
           this.inFlightJobs.delete(job)
         }
       })
+
+      if (!scheduledJob) {
+        Logger.error(
+          Logs.error.jobSchedule
+            .replaceAll('{JOB}', job.name)
+            .replaceAll('{SCHEDULE}', job.schedule),
+        )
+        continue
+      }
+
       this.scheduledJobs.push(scheduledJob)
       Logger.info(
         Logs.info.jobScheduled.replaceAll('{JOB}', job.name).replaceAll('{SCHEDULE}', job.schedule),
@@ -67,6 +96,10 @@ export class JobService {
     }
   }
 
+  /**
+   * Cancels future invocations and allows the schedules to be started again.
+   * Runs already in flight are neither interrupted nor awaited.
+   */
   public stop(): void {
     for (const scheduledJob of this.scheduledJobs) {
       scheduledJob.cancel()

--- a/src/services/job-service.ts
+++ b/src/services/job-service.ts
@@ -1,6 +1,7 @@
 import { CronExpressionParser } from 'cron-parser'
 import { DateTime } from 'luxon'
 import schedule from 'node-schedule'
+import { type Job as ScheduledJob } from 'node-schedule'
 import { createRequire } from 'node:module'
 
 import { Logger } from './index.js'
@@ -10,9 +11,19 @@ const require = createRequire(import.meta.url)
 const Logs = require('../../lang/logs.json')
 
 export class JobService {
+  private inFlightJobs = new Set<Job>()
+  private scheduledJobs: ScheduledJob[] = []
+  private started = false
+
   constructor(private jobs: Job[]) {}
 
   public start(): void {
+    if (this.started) {
+      return
+    }
+
+    this.started = true
+
     for (const job of this.jobs) {
       const jobSchedule = job.runOnce
         ? CronExpressionParser.parse(job.schedule, {
@@ -25,7 +36,14 @@ export class JobService {
             rule: job.schedule,
           }
 
-      schedule.scheduleJob(jobSchedule, async () => {
+      const scheduledJob = schedule.scheduleJob(jobSchedule, async () => {
+        if (this.inFlightJobs.has(job)) {
+          Logger.warn(Logs.warn.jobSkipped.replaceAll('{JOB}', job.name))
+          return
+        }
+
+        this.inFlightJobs.add(job)
+
         try {
           if (job.log) {
             Logger.info(Logs.info.jobRun.replaceAll('{JOB}', job.name))
@@ -38,11 +56,23 @@ export class JobService {
           }
         } catch (error) {
           Logger.error(Logs.error.job.replaceAll('{JOB}', job.name), error)
+        } finally {
+          this.inFlightJobs.delete(job)
         }
       })
+      this.scheduledJobs.push(scheduledJob)
       Logger.info(
         Logs.info.jobScheduled.replaceAll('{JOB}', job.name).replaceAll('{SCHEDULE}', job.schedule),
       )
     }
+  }
+
+  public stop(): void {
+    for (const scheduledJob of this.scheduledJobs) {
+      scheduledJob.cancel()
+    }
+
+    this.scheduledJobs = []
+    this.started = false
   }
 }

--- a/tests/services/job-service.test.ts
+++ b/tests/services/job-service.test.ts
@@ -1,6 +1,7 @@
 import schedule, { type JobCallback, type Spec } from 'node-schedule'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import Logs from '../../lang/logs.json' with { type: 'json' }
 import { type Job } from '../../src/jobs/index.js'
 import { JobService, Logger } from '../../src/services/index.js'
 
@@ -10,10 +11,10 @@ vi.mock('node-schedule', () => ({
   },
 }))
 
-function createJob(name: string, run: () => Promise<void>): Job {
+function createJob(name: string, run: () => Promise<void>, log = false): Job {
   return {
     name,
-    log: false,
+    log,
     schedule: '* * * * * *',
     runOnce: false,
     initialDelaySecs: 0,
@@ -83,6 +84,25 @@ describe('JobService', () => {
     expect(schedule.scheduleJob).toHaveBeenCalledTimes(4)
   })
 
+  it('reports an invalid schedule without retaining an empty scheduled job', () => {
+    vi.mocked(schedule.scheduleJob).mockReturnValueOnce(null as never)
+    const service = new JobService([createJob('invalid job', vi.fn().mockResolvedValue(undefined))])
+
+    service.start()
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      Logs.error.jobSchedule
+        .replaceAll('{JOB}', 'invalid job')
+        .replaceAll('{SCHEDULE}', '* * * * * *'),
+    )
+    expect(Logger.info).not.toHaveBeenCalledWith(
+      Logs.info.jobScheduled
+        .replaceAll('{JOB}', 'invalid job')
+        .replaceAll('{SCHEDULE}', '* * * * * *'),
+    )
+    expect(() => service.stop()).not.toThrow()
+  })
+
   it('skips an overlapping run of the same job and resumes after completion', async () => {
     const deferred = createDeferred()
     const run = vi.fn(() => deferred.promise)
@@ -96,7 +116,7 @@ describe('JobService', () => {
 
     expect(run).toHaveBeenCalledOnce()
     expect(Logger.warn).toHaveBeenCalledWith(
-      "Skipped job 'slow job' because its previous run is still active.",
+      Logs.warn.jobSkipped.replaceAll('{JOB}', 'slow job').replaceAll('{DURATION_SECONDS}', '0'),
     )
 
     deferred.resolve()
@@ -104,6 +124,36 @@ describe('JobService', () => {
     await callbacks[0]?.(new Date())
 
     expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports elapsed time and escalates a stuck run once', async () => {
+    const deferred = createDeferred()
+    const run = vi.fn(() => deferred.promise)
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    const service = new JobService([createJob('stuck job', run)])
+    service.start()
+
+    const firstRun = Promise.resolve(callbacks[0]?.(new Date()))
+    await vi.waitFor(() => expect(run).toHaveBeenCalledOnce())
+
+    now.mockReturnValue(6_000)
+    await callbacks[0]?.(new Date())
+
+    expect(Logger.warn).toHaveBeenCalledWith(
+      Logs.warn.jobSkipped.replaceAll('{JOB}', 'stuck job').replaceAll('{DURATION_SECONDS}', '5'),
+    )
+
+    now.mockReturnValue(3_601_000)
+    await callbacks[0]?.(new Date())
+    await callbacks[0]?.(new Date())
+
+    expect(Logger.error).toHaveBeenCalledOnce()
+    expect(Logger.error).toHaveBeenCalledWith(
+      Logs.error.jobStuck.replaceAll('{JOB}', 'stuck job').replaceAll('{DURATION_SECONDS}', '3600'),
+    )
+
+    deferred.resolve()
+    await firstRun
   })
 
   it('allows different jobs to run concurrently', async () => {
@@ -139,5 +189,19 @@ describe('JobService', () => {
 
     expect(run).toHaveBeenCalledTimes(2)
     expect(Logger.error).toHaveBeenCalledOnce()
+  })
+
+  it('logs the start and completion of jobs configured for informational logging', async () => {
+    const service = new JobService([
+      createJob('logged job', vi.fn().mockResolvedValue(undefined), true),
+    ])
+    service.start()
+
+    await callbacks[0]?.(new Date())
+
+    expect(Logger.info).toHaveBeenCalledWith(Logs.info.jobRun.replaceAll('{JOB}', 'logged job'))
+    expect(Logger.info).toHaveBeenCalledWith(
+      Logs.info.jobCompleted.replaceAll('{JOB}', 'logged job'),
+    )
   })
 })

--- a/tests/services/job-service.test.ts
+++ b/tests/services/job-service.test.ts
@@ -1,0 +1,143 @@
+import schedule, { type JobCallback, type Spec } from 'node-schedule'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type Job } from '../../src/jobs/index.js'
+import { JobService, Logger } from '../../src/services/index.js'
+
+vi.mock('node-schedule', () => ({
+  default: {
+    scheduleJob: vi.fn(),
+  },
+}))
+
+function createJob(name: string, run: () => Promise<void>): Job {
+  return {
+    name,
+    log: false,
+    schedule: '* * * * * *',
+    runOnce: false,
+    initialDelaySecs: 0,
+    run,
+  }
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => undefined
+  const promise = new Promise<void>((fulfill) => {
+    resolve = fulfill
+  })
+
+  return { promise, resolve }
+}
+
+describe('JobService', () => {
+  let callbacks: JobCallback[]
+  let cancelMocks: Array<ReturnType<typeof vi.fn>>
+
+  beforeEach(() => {
+    callbacks = []
+    cancelMocks = []
+
+    vi.mocked(schedule.scheduleJob).mockReset()
+    vi.mocked(schedule.scheduleJob).mockImplementation(((_spec: Spec, callback: JobCallback) => {
+      const cancel = vi.fn(() => true)
+      callbacks.push(callback)
+      cancelMocks.push(cancel)
+
+      return { cancel }
+    }) as unknown as typeof schedule.scheduleJob)
+
+    vi.spyOn(Logger, 'info').mockImplementation(() => undefined)
+    vi.spyOn(Logger, 'warn').mockImplementation(() => undefined)
+    vi.spyOn(Logger, 'error').mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not register duplicate schedules when started more than once', () => {
+    const service = new JobService([createJob('job', vi.fn().mockResolvedValue(undefined))])
+
+    service.start()
+    service.start()
+
+    expect(schedule.scheduleJob).toHaveBeenCalledOnce()
+  })
+
+  it('cancels every scheduled job and can be started again', () => {
+    const service = new JobService([
+      createJob('first', vi.fn().mockResolvedValue(undefined)),
+      createJob('second', vi.fn().mockResolvedValue(undefined)),
+    ])
+
+    service.start()
+    service.stop()
+
+    expect(cancelMocks).toHaveLength(2)
+    expect(cancelMocks[0]).toHaveBeenCalledOnce()
+    expect(cancelMocks[1]).toHaveBeenCalledOnce()
+
+    service.start()
+
+    expect(schedule.scheduleJob).toHaveBeenCalledTimes(4)
+  })
+
+  it('skips an overlapping run of the same job and resumes after completion', async () => {
+    const deferred = createDeferred()
+    const run = vi.fn(() => deferred.promise)
+    const service = new JobService([createJob('slow job', run)])
+    service.start()
+
+    const firstRun = Promise.resolve(callbacks[0]?.(new Date()))
+    await vi.waitFor(() => expect(run).toHaveBeenCalledOnce())
+
+    await callbacks[0]?.(new Date())
+
+    expect(run).toHaveBeenCalledOnce()
+    expect(Logger.warn).toHaveBeenCalledWith(
+      "Skipped job 'slow job' because its previous run is still active.",
+    )
+
+    deferred.resolve()
+    await firstRun
+    await callbacks[0]?.(new Date())
+
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('allows different jobs to run concurrently', async () => {
+    const firstDeferred = createDeferred()
+    const secondDeferred = createDeferred()
+    const firstRun = vi.fn(() => firstDeferred.promise)
+    const secondRun = vi.fn(() => secondDeferred.promise)
+    const service = new JobService([createJob('first', firstRun), createJob('second', secondRun)])
+    service.start()
+
+    const firstInvocation = Promise.resolve(callbacks[0]?.(new Date()))
+    const secondInvocation = Promise.resolve(callbacks[1]?.(new Date()))
+    await vi.waitFor(() => {
+      expect(firstRun).toHaveBeenCalledOnce()
+      expect(secondRun).toHaveBeenCalledOnce()
+    })
+
+    firstDeferred.resolve()
+    secondDeferred.resolve()
+    await Promise.all([firstInvocation, secondInvocation])
+  })
+
+  it('allows the next run after a failure', async () => {
+    const run = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('failed'))
+      .mockResolvedValueOnce(undefined)
+    const service = new JobService([createJob('job', run)])
+    service.start()
+
+    await callbacks[0]?.(new Date())
+    await callbacks[0]?.(new Date())
+
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(Logger.error).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary

- prevent a scheduled job from overlapping with its own active invocation
- log skipped invocations while allowing different jobs to run concurrently
- make scheduler startup idempotent and add clean cancellation through `stop()`
- add focused coverage for overlap prevention, success/failure recovery, concurrency, and cancellation

## Why

`JobService` did not track in-flight async callbacks or scheduled handles. A job that ran longer than its interval could start again before completing, risking duplicate external writes in calendar reconciliation and duplicate welcome-thread processing.

## Impact

Each job now has an independent in-flight guard. Repeated scheduler startup no longer creates duplicate schedules, and retained handles can be canceled cleanly.

## Validation

- `npm test` — 135 tests passed
- `npm run check-types`
- ESLint on changed TypeScript files
- Prettier check on changed files
- `git diff --check`

Closes #141