### PR TITLE
Prevent skipped Claude runs from cancelling reviews

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,10 +11,6 @@ on:
   pull_request_review:
     types: [submitted]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   claude-review:
     if: |
@@ -22,6 +18,9 @@ jobs:
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What changed

- Move Claude review concurrency from workflow scope to the `claude-review` job.

## Why

Claude posts a progress comment while reviewing. That comment creates an `issue_comment` workflow run whose job is skipped, but its workflow-level concurrency group previously cancelled the active review. Job-level concurrency only applies to real review jobs.

## Validation

- Prettier check passed for `.github/workflows/claude-review.yml`.
- `git diff --check` passed.