### PR TITLE
Add fractional sum test

### DIFF
--- a/tests/utils/math-utils.test.ts
+++ b/tests/utils/math-utils.test.ts
@@ -20,6 +20,11 @@ describe('MathUtils', () => {
       const result = MathUtils.sum(input)
       expect(result).toBe(4)
     })
+
+    it('should sum fractional numbers', () => {
+      const result = MathUtils.sum([1.5, 2.25, 0.25])
+      expect(result).toBe(4)
+    })
   })
 
   describe('clamp', () => {


### PR DESCRIPTION
## What changed

Adds a focused unit test covering fractional-number summation in `MathUtils.sum`.

## Why

Provides a small test-only change to verify the PR workflow and extend coverage for numeric inputs.

## Validation

- `npm test -- tests/utils/math-utils.test.ts` — 1 file passed, 15 tests passed.