### PR TITLE
Enforce auth on the manager API and move it to port 3000

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,5 +39,6 @@ PORT=3000
 # start without it. Use a long random value per environment.
 DISCORD_BOT_API_SECRET="generate-a-long-random-string"
 
-# optional / unused
+# Required to start, but only sent anywhere when config.json clustering.enabled
+# is true (it is false by default). Any non-empty value works until then.
 DISCORD_BOT_MASTER_API_TOKEN="test-passing-var"

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ BACKUP_S3_PREFIX=discord-bot/sqlite
 CRM_API_URL="http://localhost:8080"
 CRM_API_TOKEN="paste-token-from-django-admin"
 
+PORT=3000
+
 # optional: hourly sync of Discord scheduled events → DGG Google Calendar (service account)
 # GOOGLE_CALENDAR_ID="your-calendar-id@group.calendar.google.com"
 # GOOGLE_APPLICATION_CREDENTIALS="path/to/service-account.json"
@@ -31,7 +33,11 @@ CRM_API_TOKEN="paste-token-from-django-admin"
 # DM proxy integration: shared secret the CRM sends in the Authorization header
 # of POST /integrations/send-dm. Unset disables the endpoint (404).
 # INTEGRATION_DM_PROXY="generate-a-long-random-string"
+#
+# Manager API auth: shared secret required in the Authorization header of
+# GET /guilds, GET /shards, and PUT /shards/presence. The manager refuses to
+# start without it. Use a long random value per environment.
+DISCORD_BOT_API_SECRET="generate-a-long-random-string"
 
 # optional / unused
 DISCORD_BOT_MASTER_API_TOKEN="test-passing-var"
-DISCORD_BOT_API_SECRET="test-passing-var"

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,8 @@ BACKUP_S3_PREFIX=discord-bot/sqlite
 CRM_API_URL="http://localhost:8080"
 CRM_API_TOKEN="paste-token-from-django-admin"
 
-PORT=3000
+# optional: overrides config.json api.port. Coolify injects this; leave unset locally.
+# PORT=3000
 
 # optional: hourly sync of Discord scheduled events → DGG Google Calendar (service account)
 # GOOGLE_CALENDAR_ID="your-calendar-id@group.calendar.google.com"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,11 @@ COPY config/debug.example.json config/debug.json
 RUN npm run build
 
 # Expose ports
-EXPOSE 3001
+EXPOSE 3000
 
 # Let Coolify verify that the manager API is accepting requests.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5m --retries=3 \
-  CMD node -e "fetch('http://127.0.0.1:3001/health').then((response) => { if (!response.ok) process.exit(1) }).catch(() => process.exit(1))"
+  CMD node -e "fetch('http://127.0.0.1:3000/health').then((response) => { if (!response.ok) process.exit(1) }).catch(() => process.exit(1))"
 
 # Push the database schema against the runtime-mounted SQLite file, then start the app.
 CMD if [ -n "$SQLITE_PATH" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ EXPOSE 3000
 
 # Let Coolify verify that the manager API is accepting requests.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5m --retries=3 \
-  CMD node -e "fetch('http://127.0.0.1:3000/health').then((response) => { if (!response.ok) process.exit(1) }).catch(() => process.exit(1))"
+  CMD node -e "fetch('http://127.0.0.1:${PORT:-3000}/health').then((response) => { if (!response.ok) process.exit(1) }).catch(() => process.exit(1))"
 
 # Push the database schema against the runtime-mounted SQLite file, then start the app.
 CMD if [ -n "$SQLITE_PATH" ]; then \

--- a/config/config.json
+++ b/config/config.json
@@ -31,7 +31,7 @@
     }
   },
   "api": {
-    "port": 3001,
+    "port": 3000,
     "// NOTE: secret is now managed via environment variables": ""
   },
   "sharding": {
@@ -42,7 +42,7 @@
   "clustering": {
     "enabled": false,
     "shardCount": 16,
-    "callbackUrl": "http://localhost:3001/",
+    "callbackUrl": "http://localhost:3000/",
     "masterApi": {
       "url": "http://localhost:5000/",
       "// NOTE: token is now managed via environment variables": ""

--- a/docs/DmProxyIntegration.md
+++ b/docs/DmProxyIntegration.md
@@ -64,7 +64,7 @@ spawning would otherwise leave the request open indefinitely. The cap turns that
 ## Example
 
 ```bash
-curl -X POST http://localhost:3001/integrations/send-dm \
+curl -X POST http://localhost:3000/integrations/send-dm \
   -H "Content-Type: application/json" \
   -H "Authorization: abc123" \
   -d '{

--- a/docs/PragmaticPapersIntegration.md
+++ b/docs/PragmaticPapersIntegration.md
@@ -52,7 +52,7 @@ Payload:
 ### Volume release (multiple articles)
 
 ```bash
-curl -X POST http://localhost:9010/integrations/pp-event \
+curl -X POST http://localhost:3000/integrations/pp-event \
   -H "Content-Type: application/json" \
   -H "Authorization: abc123" \
   -d '{
@@ -79,7 +79,7 @@ curl -X POST http://localhost:9010/integrations/pp-event \
 ### Standalone article (no volume)
 
 ```bash
-curl -X POST http://localhost:9010/integrations/pp-event \
+curl -X POST http://localhost:3000/integrations/pp-event \
   -H "Content-Type: application/json" \
   -H "Authorization: abc123" \
   -d '{

--- a/misc/Discord Bot Cluster API.postman_collection.json
+++ b/misc/Discord Bot Cluster API.postman_collection.json
@@ -129,7 +129,7 @@
 	"variable": [
 		{
 			"key": "BASE_URL",
-			"value": "localhost:3001"
+			"value": "localhost:3000"
 		}
 	]
 }

--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -3,6 +3,8 @@ import { type Router } from 'express'
 export interface Controller {
   path: string
   router: Router
+  /** When true, `Api` refuses to mount the controller unless `authToken` is a non-empty string. */
+  requiresAuth?: boolean
   authToken?: string
   register(): void
 }

--- a/src/controllers/guilds-controller.ts
+++ b/src/controllers/guilds-controller.ts
@@ -7,6 +7,7 @@ import { type GetGuildsResponse } from '../models/cluster-api/index.js'
 export class GuildsController implements Controller {
   public path = '/guilds'
   public router: Router = Router()
+  public requiresAuth = true
   public authToken: string = process.env.DISCORD_BOT_API_SECRET
 
   constructor(private shardManager: ShardingManager) {}

--- a/src/controllers/guilds-controller.ts
+++ b/src/controllers/guilds-controller.ts
@@ -1,17 +1,13 @@
 import { type ShardingManager } from 'discord.js'
 import { type Request, type Response, Router } from 'express'
-import { createRequire } from 'node:module'
 
 import { type Controller } from './index.js'
 import { type GetGuildsResponse } from '../models/cluster-api/index.js'
 
-const require = createRequire(import.meta.url)
-const Config = require('../../config/config.json')
-
 export class GuildsController implements Controller {
   public path = '/guilds'
   public router: Router = Router()
-  public authToken: string = Config.api.secret
+  public authToken: string = process.env.DISCORD_BOT_API_SECRET
 
   constructor(private shardManager: ShardingManager) {}
 

--- a/src/controllers/shards-controller.ts
+++ b/src/controllers/shards-controller.ts
@@ -14,13 +14,12 @@ import {
 import { Logger } from '../services/index.js'
 
 const require = createRequire(import.meta.url)
-const Config = require('../../config/config.json')
 const Logs = require('../../lang/logs.json')
 
 export class ShardsController implements Controller {
   public path = '/shards'
   public router: Router = Router()
-  public authToken: string = Config.api.secret
+  public authToken: string = process.env.DISCORD_BOT_API_SECRET
 
   constructor(private shardManager: ShardingManager) {}
 

--- a/src/controllers/shards-controller.ts
+++ b/src/controllers/shards-controller.ts
@@ -19,6 +19,7 @@ const Logs = require('../../lang/logs.json')
 export class ShardsController implements Controller {
   public path = '/shards'
   public router: Router = Router()
+  public requiresAuth = true
   public authToken: string = process.env.DISCORD_BOT_API_SECRET
 
   constructor(private shardManager: ShardingManager) {}

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -7,6 +7,7 @@ declare global {
       DISCORD_BOT_MASTER_API_TOKEN: string
       DISCORD_BOT_DEVELOPER_IDS: string // comma-separated list of Discord user IDs
       INTEGRATION_DM_PROXY?: string // unset disables the /integrations/send-dm endpoint
+      PORT?: string // overrides config.api.port when set (injected by the hosting platform)
       SQLITE_PATH: string
       NODE_ENV: 'development' | 'production' | 'test'
     }

--- a/src/middleware/check-auth.ts
+++ b/src/middleware/check-auth.ts
@@ -1,8 +1,19 @@
 import { type RequestHandler } from 'express'
+import { timingSafeEqual } from 'node:crypto'
+
+function tokensMatch(provided: string, expected: string): boolean {
+  const providedBuffer = Buffer.from(provided)
+  const expectedBuffer = Buffer.from(expected)
+  return (
+    providedBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(providedBuffer, expectedBuffer)
+  )
+}
 
 export function checkAuth(token: string): RequestHandler {
   return (req, res, next) => {
-    if (req.headers.authorization !== token) {
+    const provided = req.headers.authorization
+    if (!provided || !tokensMatch(provided, token)) {
       res.sendStatus(401)
       return
     }

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -28,7 +28,12 @@ export class Api {
 
   private setupControllers(): void {
     for (const controller of this.controllers) {
-      if (controller.authToken) {
+      if ('authToken' in controller) {
+        if (!controller.authToken) {
+          throw new Error(
+            `Controller '${controller.path}' requires an auth token but none is configured; refusing to mount it unauthenticated.`,
+          )
+        }
         controller.router.use(checkAuth(controller.authToken))
       }
       controller.register()

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -16,11 +16,12 @@ export class Api {
 
   constructor(public controllers: Controller[]) {
     const portOverride = process.env.PORT
-    if (portOverride !== undefined && portOverride !== '' && !/^\d+$/.test(portOverride)) {
+    const parsedPort = Number(portOverride)
+    if (portOverride && (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535)) {
       throw new Error(`Invalid PORT: '${portOverride}'`)
     }
 
-    this.port = Number(portOverride) || Config.api.port
+    this.port = parsedPort || Config.api.port
     this.app = express()
     this.app.use(express.json())
     this.setupControllers()

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -29,7 +29,7 @@ export class Api {
 
   private setupControllers(): void {
     for (const controller of this.controllers) {
-      if ('authToken' in controller) {
+      if (controller.requiresAuth) {
         if (!controller.authToken) {
           throw new Error(
             `Controller '${controller.path}' requires an auth token but none is configured; refusing to mount it unauthenticated.`,

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -12,8 +12,15 @@ const Logs = require('../../lang/logs.json')
 
 export class Api {
   public app: Express
+  private readonly port: number
 
   constructor(public controllers: Controller[]) {
+    const portOverride = process.env.PORT
+    if (portOverride !== undefined && portOverride !== '' && !/^\d+$/.test(portOverride)) {
+      throw new Error(`Invalid PORT: '${portOverride}'`)
+    }
+
+    this.port = Number(portOverride) || Config.api.port
     this.app = express()
     this.app.use(express.json())
     this.setupControllers()
@@ -22,9 +29,9 @@ export class Api {
 
   public async start(): Promise<void> {
     const listen = util.promisify(this.app.listen.bind(this.app))
-    const port = Number(process.env.PORT) || Config.api.port
-    await listen(port)
-    Logger.info(Logs.info.apiStarted.replaceAll('{PORT}', String(port)))
+
+    await listen(this.port)
+    Logger.info(Logs.info.apiStarted.replaceAll('{PORT}', String(this.port)))
   }
 
   private setupControllers(): void {

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -16,10 +16,11 @@ export class Api {
 
   constructor(public controllers: Controller[]) {
     const portOverride = process.env.PORT
-    const parsedPort = Number(portOverride)
+    
     if (portOverride && !/^\d+$/.test(portOverride)) {
       throw new Error(`Invalid PORT: '${portOverride}'`)
     }
+    
     const parsedPort = Number(portOverride)
     if (portOverride && (parsedPort < 1 || parsedPort > 65535)) {
       throw new Error(`Invalid PORT: '${portOverride}'`)

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -16,11 +16,11 @@ export class Api {
 
   constructor(public controllers: Controller[]) {
     const portOverride = process.env.PORT
-    
+
     if (portOverride && !/^\d+$/.test(portOverride)) {
       throw new Error(`Invalid PORT: '${portOverride}'`)
     }
-    
+
     const parsedPort = Number(portOverride)
     if (portOverride && (parsedPort < 1 || parsedPort > 65535)) {
       throw new Error(`Invalid PORT: '${portOverride}'`)

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -17,7 +17,11 @@ export class Api {
   constructor(public controllers: Controller[]) {
     const portOverride = process.env.PORT
     const parsedPort = Number(portOverride)
-    if (portOverride && (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535)) {
+    if (portOverride && !/^\d+$/.test(portOverride)) {
+      throw new Error(`Invalid PORT: '${portOverride}'`)
+    }
+    const parsedPort = Number(portOverride)
+    if (portOverride && (parsedPort < 1 || parsedPort > 65535)) {
       throw new Error(`Invalid PORT: '${portOverride}'`)
     }
 

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -22,8 +22,9 @@ export class Api {
 
   public async start(): Promise<void> {
     const listen = util.promisify(this.app.listen.bind(this.app))
-    await listen(Config.api.port)
-    Logger.info(Logs.info.apiStarted.replaceAll('{PORT}', Config.api.port))
+    const port = Number(process.env.PORT) || Config.api.port
+    await listen(port)
+    Logger.info(Logs.info.apiStarted.replaceAll('{PORT}', String(port)))
   }
 
   private setupControllers(): void {

--- a/tests/controllers/guilds-controller.test.ts
+++ b/tests/controllers/guilds-controller.test.ts
@@ -21,11 +21,11 @@ function buildApp(): Express {
 
 describe('GuildsController', () => {
   beforeEach(() => {
-    process.env.DISCORD_BOT_API_SECRET = SECRET
+    vi.stubEnv('DISCORD_BOT_API_SECRET', SECRET)
   })
 
   afterEach(() => {
-    Reflect.deleteProperty(process.env, 'DISCORD_BOT_API_SECRET')
+    vi.unstubAllEnvs()
   })
 
   it('returns 401 when the Authorization header is missing', async () => {
@@ -34,7 +34,13 @@ describe('GuildsController', () => {
     expect(res.status).toBe(401)
   })
 
-  it('returns 401 when the Authorization header is wrong', async () => {
+  it('returns 401 when the token is wrong but the same length as the secret', async () => {
+    const res = await request(buildApp()).get('/guilds').set('Authorization', 'nope-api-secret')
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when the token is a different length from the secret', async () => {
     const res = await request(buildApp()).get('/guilds').set('Authorization', 'wrong-secret')
 
     expect(res.status).toBe(401)
@@ -48,7 +54,7 @@ describe('GuildsController', () => {
   })
 
   it('refuses to mount the controller when no secret is configured', () => {
-    process.env.DISCORD_BOT_API_SECRET = ''
+    vi.stubEnv('DISCORD_BOT_API_SECRET', '')
 
     expect(() => buildApp()).toThrow(/auth token/)
   })

--- a/tests/controllers/guilds-controller.test.ts
+++ b/tests/controllers/guilds-controller.test.ts
@@ -1,0 +1,55 @@
+import { type ShardingManager } from 'discord.js'
+import { type Express } from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { GuildsController } from '../../src/controllers/guilds-controller.js'
+import { Api } from '../../src/models/api.js'
+
+const SECRET = 'test-api-secret'
+
+function buildApp(): Express {
+  const shardManager = {
+    broadcastEval: vi.fn(async () => [
+      ['111111111111111111', '222222222222222222'],
+      ['222222222222222222'],
+    ]),
+  } as unknown as ShardingManager
+  const api = new Api([new GuildsController(shardManager)])
+  return api.app
+}
+
+describe('GuildsController', () => {
+  beforeEach(() => {
+    process.env.DISCORD_BOT_API_SECRET = SECRET
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, 'DISCORD_BOT_API_SECRET')
+  })
+
+  it('returns 401 when the Authorization header is missing', async () => {
+    const res = await request(buildApp()).get('/guilds')
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when the Authorization header is wrong', async () => {
+    const res = await request(buildApp()).get('/guilds').set('Authorization', 'wrong-secret')
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns the deduplicated guild ids with the correct token', async () => {
+    const res = await request(buildApp()).get('/guilds').set('Authorization', SECRET)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ guilds: ['111111111111111111', '222222222222222222'] })
+  })
+
+  it('refuses to mount the controller when no secret is configured', () => {
+    process.env.DISCORD_BOT_API_SECRET = ''
+
+    expect(() => buildApp()).toThrow(/auth token/)
+  })
+})

--- a/tests/controllers/shards-controller.test.ts
+++ b/tests/controllers/shards-controller.test.ts
@@ -1,0 +1,80 @@
+import { type ShardingManager } from 'discord.js'
+import { type Express } from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ShardsController } from '../../src/controllers/shards-controller.js'
+import { Api } from '../../src/models/api.js'
+
+const SECRET = 'test-api-secret'
+
+type FakeShard = {
+  id: number
+  ready: boolean
+  fetchClientValue: ReturnType<typeof vi.fn>
+}
+
+function makeShardManager(): { manager: ShardingManager; broadcastEval: ReturnType<typeof vi.fn> } {
+  const shard: FakeShard = {
+    id: 0,
+    ready: true,
+    fetchClientValue: vi.fn(async () => 123_456),
+  }
+  const broadcastEval = vi.fn(async () => [])
+  const manager = {
+    shards: {
+      size: 1,
+      map: <T>(fn: (shard: FakeShard) => T): T[] => [fn(shard)],
+    },
+    broadcastEval,
+  } as unknown as ShardingManager
+  return { manager, broadcastEval }
+}
+
+function buildApp(manager?: ShardingManager): Express {
+  const shardManager = manager ?? makeShardManager().manager
+  const api = new Api([new ShardsController(shardManager)])
+  return api.app
+}
+
+describe('ShardsController', () => {
+  beforeEach(() => {
+    process.env.DISCORD_BOT_API_SECRET = SECRET
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, 'DISCORD_BOT_API_SECRET')
+  })
+
+  it('returns 401 for GET /shards without the Authorization header', async () => {
+    const res = await request(buildApp()).get('/shards')
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 for PUT /shards/presence without the Authorization header', async () => {
+    const res = await request(buildApp()).put('/shards/presence').send({})
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns shard stats with the correct token', async () => {
+    const res = await request(buildApp()).get('/shards').set('Authorization', SECRET)
+
+    expect(res.status).toBe(200)
+    expect(res.body.shards).toEqual([{ id: 0, ready: true, error: false, uptimeSecs: 123 }])
+    expect(res.body.stats.shardCount).toBe(1)
+  })
+
+  it('sets shard presences with the correct token', async () => {
+    const { manager, broadcastEval } = makeShardManager()
+
+    const res = await request(buildApp(manager))
+      .put('/shards/presence')
+      .set('Authorization', SECRET)
+      .send({ type: 'Playing', name: 'a test status', url: 'https://example.com/' })
+
+    expect(res.status).toBe(200)
+    expect(broadcastEval).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/controllers/shards-controller.test.ts
+++ b/tests/controllers/shards-controller.test.ts
@@ -39,11 +39,11 @@ function buildApp(manager?: ShardingManager): Express {
 
 describe('ShardsController', () => {
   beforeEach(() => {
-    process.env.DISCORD_BOT_API_SECRET = SECRET
+    vi.stubEnv('DISCORD_BOT_API_SECRET', SECRET)
   })
 
   afterEach(() => {
-    Reflect.deleteProperty(process.env, 'DISCORD_BOT_API_SECRET')
+    vi.unstubAllEnvs()
   })
 
   it('returns 401 for GET /shards without the Authorization header', async () => {
@@ -52,8 +52,23 @@ describe('ShardsController', () => {
     expect(res.status).toBe(401)
   })
 
+  it('returns 401 for GET /shards with a wrong token of the same length as the secret', async () => {
+    const res = await request(buildApp()).get('/shards').set('Authorization', 'nope-api-secret')
+
+    expect(res.status).toBe(401)
+  })
+
   it('returns 401 for PUT /shards/presence without the Authorization header', async () => {
     const res = await request(buildApp()).put('/shards/presence').send({})
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 for PUT /shards/presence with a wrong token', async () => {
+    const res = await request(buildApp())
+      .put('/shards/presence')
+      .set('Authorization', 'nope-api-secret')
+      .send({ type: 'Playing', name: 'a test status', url: 'https://example.com/' })
 
     expect(res.status).toBe(401)
   })

--- a/tests/models/api.test.ts
+++ b/tests/models/api.test.ts
@@ -45,4 +45,16 @@ describe('Api', () => {
 
     expect(() => new Api([])).toThrow("Invalid PORT: 'invalid'")
   })
+
+  it('rejects a PORT above the valid range during construction', () => {
+    vi.stubEnv('PORT', '70000')
+
+    expect(() => new Api([])).toThrow("Invalid PORT: '70000'")
+  })
+
+  it('rejects PORT=0 rather than silently falling back to the configured port', () => {
+    vi.stubEnv('PORT', '0')
+
+    expect(() => new Api([])).toThrow("Invalid PORT: '0'")
+  })
 })

--- a/tests/models/api.test.ts
+++ b/tests/models/api.test.ts
@@ -39,4 +39,10 @@ describe('Api', () => {
 
     expect(listen).toHaveBeenCalledWith(3000, expect.any(Function))
   })
+
+  it('rejects an invalid PORT during construction', () => {
+    vi.stubEnv('PORT', 'invalid')
+
+    expect(() => new Api([])).toThrow("Invalid PORT: 'invalid'")
+  })
 })

--- a/tests/models/api.test.ts
+++ b/tests/models/api.test.ts
@@ -1,0 +1,42 @@
+import { type Express } from 'express'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Api } from '../../src/models/api.js'
+import { Logger } from '../../src/services/index.js'
+
+function stubListen(api: Api): ReturnType<typeof vi.fn> {
+  const listen = vi.fn((port: number, callback: () => void) => callback())
+  api.app.listen = listen as unknown as Express['listen']
+  return listen
+}
+
+describe('Api', () => {
+  beforeEach(() => {
+    vi.spyOn(Logger, 'info').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('listens on the PORT env var when set', async () => {
+    vi.stubEnv('PORT', '4567')
+    const api = new Api([])
+    const listen = stubListen(api)
+
+    await api.start()
+
+    expect(listen).toHaveBeenCalledWith(4567, expect.any(Function))
+  })
+
+  it('falls back to the configured port when PORT is unset', async () => {
+    vi.stubEnv('PORT', '')
+    const api = new Api([])
+    const listen = stubListen(api)
+
+    await api.start()
+
+    expect(listen).toHaveBeenCalledWith(3000, expect.any(Function))
+  })
+})


### PR DESCRIPTION
## Summary

The manager API's `GET /guilds`, `GET /shards`, and `PUT /shards/presence` routes are currently served with no authentication: the controllers read their token from `Config.api.secret`, but `config.json` stopped shipping that key when secrets moved to env vars, and `Api.setupControllers` silently skips `checkAuth` when the token is falsy. Verified against the running container — `GET /guilds` returns the guild list without an `Authorization` header. Not currently reachable from the internet, but it blocks exposing the API for the CRM DM proxy and the Pragmatic Papers webhook.

- Wire `DISCORD_BOT_API_SECRET` into the guilds/shards controllers as the auth token. It's already required at startup by `validateEnv`, and it's the same value `register()` hands to the master API as this manager's callback credential, so this matches the config note's intent. No other consumer exists, so nothing needs coordinating.
- Fail closed: `Api` now throws at startup if a controller declares `authToken` with an empty value, instead of mounting its routes unauthenticated.
- Use `crypto.timingSafeEqual` for token comparison in `checkAuth`.
- Move the manager API from 3001 to 3000. The Coolify resource defaults (Ports Exposes, generated Traefik labels, auto-assigned domain) all point at 3000 while the API listened on 3001, so the domain 502s and the API is reachable from nowhere. Moving the app to 3000 makes the existing domain route to it with zero platform changes. Dockerfile `EXPOSE`/healthcheck, the Postman collection, and doc examples updated to match (including the stale `localhost:9010` in the Pragmatic Papers doc).
- Tests pin the 401s for missing/wrong `Authorization` on all three routes, auth running before body validation, the success paths, and the fail-closed startup throw.

## Deploy notes

Merging + redeploying makes `https://pgo6lu77u9jkp7luqo97npm0.digitalgroundgame.org` serve the manager API (it currently 502s). `DISCORD_BOT_API_SECRET` is already set in Coolify with a healthy value. For the CRM DM proxy, `INTEGRATION_DM_PROXY` also needs to be set on the bot — the `/integrations/send-dm` route is skipped at startup without it.