### PR TITLE
Exit non-zero on fatal startup and CLI failures

### DIFF
--- a/src/models/bot.ts
+++ b/src/models/bot.ts
@@ -117,7 +117,9 @@ export class Bot {
       await this.client.login(token)
     } catch (error) {
       Logger.error(Logs.error.clientLogin, error)
-      return
+      // Tear down the client's sockets and timers so the process can exit.
+      await this.client.destroy()
+      throw error
     }
   }
 

--- a/src/models/bot.ts
+++ b/src/models/bot.ts
@@ -120,7 +120,7 @@ export class Bot {
       // Tear down the client's sockets and timers so the process can exit.
       // A destroy failure must not mask the login error being rethrown.
       await this.client.destroy().catch((destroyError) => {
-        Logger.error(Logs.error.clientLogin, destroyError)
+        Logger.error(Logs.error.unspecified, destroyError)
       })
       throw error
     }

--- a/src/models/bot.ts
+++ b/src/models/bot.ts
@@ -118,7 +118,10 @@ export class Bot {
     } catch (error) {
       Logger.error(Logs.error.clientLogin, error)
       // Tear down the client's sockets and timers so the process can exit.
-      await this.client.destroy()
+      // A destroy failure must not mask the login error being rethrown.
+      await this.client.destroy().catch((destroyError) => {
+        Logger.error(Logs.error.clientLogin, destroyError)
+      })
       throw error
     }
   }

--- a/src/models/manager.ts
+++ b/src/models/manager.ts
@@ -33,7 +33,12 @@ export class Manager {
       Logger.info(Logs.info.managerAllShardsSpawned)
     } catch (error) {
       Logger.error(Logs.error.managerSpawningShards, error)
-      return
+      // Kill any shards that did spawn so the process can exit instead of
+      // lingering with a partial fleet.
+      for (const shard of this.shardManager.shards.values()) {
+        shard.kill()
+      }
+      throw error
     }
 
     if (Debug.dummyMode.enabled) {

--- a/src/models/manager.ts
+++ b/src/models/manager.ts
@@ -34,14 +34,16 @@ export class Manager {
     } catch (error) {
       Logger.error(Logs.error.managerSpawningShards, error)
       // Kill any shards that did spawn so the process can exit instead of
-      // lingering with a partial fleet. kill() can throw on a shard caught
-      // mid-respawn (no process or worker attached yet); keep going so one
-      // bad shard doesn't leave the rest alive or mask the spawn error.
+      // lingering with a partial fleet. Disable respawn first, or discord.js
+      // re-forks each dying child mid-teardown. kill() can throw on a shard
+      // caught mid-respawn (no process or worker attached yet); keep going so
+      // one bad shard doesn't leave the rest alive or mask the spawn error.
+      this.shardManager.respawn = false
       for (const shard of this.shardManager.shards.values()) {
         try {
           shard.kill()
         } catch (killError) {
-          Logger.error(Logs.error.managerSpawningShards, killError)
+          Logger.error(Logs.error.unspecified, killError)
         }
       }
       throw error

--- a/src/models/manager.ts
+++ b/src/models/manager.ts
@@ -34,9 +34,15 @@ export class Manager {
     } catch (error) {
       Logger.error(Logs.error.managerSpawningShards, error)
       // Kill any shards that did spawn so the process can exit instead of
-      // lingering with a partial fleet.
+      // lingering with a partial fleet. kill() can throw on a shard caught
+      // mid-respawn (no process or worker attached yet); keep going so one
+      // bad shard doesn't leave the rest alive or mask the spawn error.
       for (const shard of this.shardManager.shards.values()) {
-        shard.kill()
+        try {
+          shard.kill()
+        } catch (killError) {
+          Logger.error(Logs.error.managerSpawningShards, killError)
+        }
       }
       throw error
     }

--- a/src/start-bot.ts
+++ b/src/start-bot.ts
@@ -70,10 +70,11 @@ async function start(): Promise<void> {
       await runCalendarSyncCli()
     } catch (error) {
       Logger.error(Logs.error.unspecified, error)
-      process.exit(1)
+      process.exitCode = 1
     }
+    // Wait for any final logs to be written.
     await new Promise((resolve) => setTimeout(resolve, 1000))
-    process.exit(0)
+    process.exit()
   }
 
   // Register
@@ -89,6 +90,7 @@ async function start(): Promise<void> {
       await commandRegistrationService.process(localCmds, process.argv)
     } catch (error) {
       Logger.error(Logs.error.commandAction, error)
+      process.exitCode = 1
     }
     // Wait for any final logs to be written.
     await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -241,4 +243,5 @@ process.on('unhandledRejection', (reason, _promise) => {
 
 start().catch((error) => {
   Logger.error(Logs.error.unspecified, error)
+  process.exitCode = 1
 })

--- a/src/start-bot.ts
+++ b/src/start-bot.ts
@@ -64,6 +64,15 @@ const require = createRequire(import.meta.url)
 const Config = require('../config/config.json')
 const Logs = require('../lang/logs.json')
 
+// Wait for any final logs to be written, then exit with the code already set
+// on process.exitCode. Exiting hard matters: as a sharding child the open IPC
+// channel to the manager would otherwise keep the event loop alive and the
+// process would hang instead of exiting.
+async function flushLogsAndExit(): Promise<never> {
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  process.exit()
+}
+
 async function start(): Promise<void> {
   if (process.argv[2] === 'calendar' && process.argv[3] === 'sync') {
     try {
@@ -72,9 +81,7 @@ async function start(): Promise<void> {
       Logger.error(Logs.error.unspecified, error)
       process.exitCode = 1
     }
-    // Wait for any final logs to be written.
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    process.exit()
+    await flushLogsAndExit()
   }
 
   // Register
@@ -92,9 +99,7 @@ async function start(): Promise<void> {
       Logger.error(Logs.error.commandAction, error)
       process.exitCode = 1
     }
-    // Wait for any final logs to be written.
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    process.exit()
+    await flushLogsAndExit()
   }
 
   // Services
@@ -243,9 +248,6 @@ process.on('unhandledRejection', (reason, _promise) => {
 
 start().catch(async (error) => {
   Logger.error(Logs.error.unspecified, error)
-  // Wait for any final logs to be written, then exit hard: as a sharding
-  // child the open IPC channel to the manager would otherwise keep the
-  // event loop alive and the process would hang instead of exiting.
-  await new Promise((resolve) => setTimeout(resolve, 1000))
-  process.exit(1)
+  process.exitCode = 1
+  await flushLogsAndExit()
 })

--- a/src/start-bot.ts
+++ b/src/start-bot.ts
@@ -241,7 +241,11 @@ process.on('unhandledRejection', (reason, _promise) => {
   Logger.error(Logs.error.unhandledRejection, reason)
 })
 
-start().catch((error) => {
+start().catch(async (error) => {
   Logger.error(Logs.error.unspecified, error)
-  process.exitCode = 1
+  // Wait for any final logs to be written, then exit hard: as a sharding
+  // child the open IPC channel to the manager would otherwise keep the
+  // event loop alive and the process would hang instead of exiting.
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  process.exit(1)
 })

--- a/src/start-manager.ts
+++ b/src/start-manager.ts
@@ -111,7 +111,12 @@ process.on('unhandledRejection', (reason, _promise) => {
   Logger.error(Logs.error.unhandledRejection, reason)
 })
 
-start().catch((error) => {
+start().catch(async (error) => {
   Logger.error(Logs.error.unspecified, error)
-  process.exitCode = 1
+  // A failure after shards spawn (e.g. the master API ready call) leaves
+  // shard child processes and the API server keeping the event loop alive,
+  // so wait for logs to flush and exit hard instead of waiting for a drain
+  // that never comes.
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  process.exit(1)
 })

--- a/src/start-manager.ts
+++ b/src/start-manager.ts
@@ -59,13 +59,11 @@ async function start(): Promise<void> {
   }
 
   if (shardList.length === 0) {
+    // The process exits here without starting the API either way, so an
+    // empty shard list is fatal to the deployment regardless of clustering —
+    // report it as a failure instead of exiting 0.
     Logger.warn(Logs.warn.managerNoShards)
-    if (!Config.clustering.enabled) {
-      // Without clustering the shard list comes from Discord's recommended
-      // count, so an empty list means something is broken. With clustering the
-      // master can legitimately assign zero shards during a rebalance.
-      process.exitCode = 1
-    }
+    process.exitCode = 1
     return
   }
 

--- a/src/start-manager.ts
+++ b/src/start-manager.ts
@@ -54,11 +54,18 @@ async function start(): Promise<void> {
     }
   } catch (error) {
     Logger.error(Logs.error.retrieveShards, error)
+    process.exitCode = 1
     return
   }
 
   if (shardList.length === 0) {
     Logger.warn(Logs.warn.managerNoShards)
+    if (!Config.clustering.enabled) {
+      // Without clustering the shard list comes from Discord's recommended
+      // count, so an empty list means something is broken. With clustering the
+      // master can legitimately assign zero shards during a rebalance.
+      process.exitCode = 1
+    }
     return
   }
 
@@ -108,4 +115,5 @@ process.on('unhandledRejection', (reason, _promise) => {
 
 start().catch((error) => {
   Logger.error(Logs.error.unspecified, error)
+  process.exitCode = 1
 })

--- a/tests/models/bot.test.ts
+++ b/tests/models/bot.test.ts
@@ -1,0 +1,68 @@
+import { type Client } from 'discord.js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Bot } from '../../src/models/bot.js'
+import { type JobService, Logger } from '../../src/services/index.js'
+
+function createMockClient(login: ReturnType<typeof vi.fn>): Client {
+  return {
+    on: vi.fn(),
+    login,
+    destroy: vi.fn().mockResolvedValue(undefined),
+    rest: { on: vi.fn() },
+  } as unknown as Client
+}
+
+function stub<T>(): T {
+  return {} as T
+}
+
+function createBot(client: Client): Bot {
+  return new Bot(
+    'test-token',
+    client,
+    stub(),
+    stub(),
+    stub(),
+    stub(),
+    stub(),
+    stub(),
+    stub(),
+    stub(),
+    stub(),
+    stub<JobService>(),
+  )
+}
+
+describe('Bot', () => {
+  beforeEach(() => {
+    vi.spyOn(Logger, 'info').mockImplementation(() => {})
+    vi.spyOn(Logger, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('logs in successfully on start', async () => {
+    const login = vi.fn().mockResolvedValue('test-token')
+    const client = createMockClient(login)
+    const bot = createBot(client)
+
+    await bot.start()
+
+    expect(login).toHaveBeenCalledWith('test-token')
+    expect(client.destroy).not.toHaveBeenCalled()
+  })
+
+  it('rethrows a login failure and destroys the client', async () => {
+    const error = new Error('invalid token')
+    const login = vi.fn().mockRejectedValue(error)
+    const client = createMockClient(login)
+    const bot = createBot(client)
+
+    await expect(bot.start()).rejects.toBe(error)
+
+    expect(client.destroy).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/models/bot.test.ts
+++ b/tests/models/bot.test.ts
@@ -65,4 +65,14 @@ describe('Bot', () => {
 
     expect(client.destroy).toHaveBeenCalledOnce()
   })
+
+  it('rethrows the login failure even when destroying the client fails', async () => {
+    const error = new Error('invalid token')
+    const login = vi.fn().mockRejectedValue(error)
+    const client = createMockClient(login)
+    vi.mocked(client.destroy).mockRejectedValue(new Error('destroy failed'))
+    const bot = createBot(client)
+
+    await expect(bot.start()).rejects.toBe(error)
+  })
 })

--- a/tests/models/manager.test.ts
+++ b/tests/models/manager.test.ts
@@ -70,4 +70,26 @@ describe('Manager', () => {
 
     expect(shard.kill).toHaveBeenCalledOnce()
   })
+
+  it('keeps killing shards and rethrows the spawn error when a kill throws', async () => {
+    const error = new Error('spawn timed out')
+    const spawn = vi.fn().mockRejectedValue(error)
+    const throwingShard = createMockShard()
+    throwingShard.kill.mockImplementation(() => {
+      throw new TypeError('no process or worker')
+    })
+    const shard = createMockShard()
+    const shardManager = createMockShardManager(
+      spawn,
+      new Map([
+        [0, throwingShard],
+        [1, shard],
+      ]),
+    )
+    const manager = new Manager(shardManager, createMockJobService())
+
+    await expect(manager.start()).rejects.toBe(error)
+
+    expect(shard.kill).toHaveBeenCalledOnce()
+  })
 })

--- a/tests/models/manager.test.ts
+++ b/tests/models/manager.test.ts
@@ -15,6 +15,7 @@ function createMockShardManager(
   return {
     shardList: [0],
     totalShards: 1,
+    respawn: true,
     on: vi.fn(),
     spawn,
     shards,
@@ -69,6 +70,7 @@ describe('Manager', () => {
     await expect(manager.start()).rejects.toBe(error)
 
     expect(shard.kill).toHaveBeenCalledOnce()
+    expect(shardManager.respawn).toBe(false)
   })
 
   it('keeps killing shards and rethrows the spawn error when a kill throws', async () => {

--- a/tests/models/manager.test.ts
+++ b/tests/models/manager.test.ts
@@ -1,0 +1,73 @@
+import { type ShardingManager } from 'discord.js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Manager } from '../../src/models/manager.js'
+import { type JobService, Logger } from '../../src/services/index.js'
+
+function createMockShard(): { kill: ReturnType<typeof vi.fn> } {
+  return { kill: vi.fn() }
+}
+
+function createMockShardManager(
+  spawn: ReturnType<typeof vi.fn>,
+  shards: Map<number, { kill: ReturnType<typeof vi.fn> }> = new Map(),
+): ShardingManager {
+  return {
+    shardList: [0],
+    totalShards: 1,
+    on: vi.fn(),
+    spawn,
+    shards,
+  } as unknown as ShardingManager
+}
+
+function createMockJobService(): JobService {
+  return { start: vi.fn() } as unknown as JobService
+}
+
+describe('Manager', () => {
+  beforeEach(() => {
+    vi.spyOn(Logger, 'info').mockImplementation(() => {})
+    vi.spyOn(Logger, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('starts jobs after a successful shard spawn', async () => {
+    const spawn = vi.fn().mockResolvedValue(new Map())
+    const shardManager = createMockShardManager(spawn)
+    const jobService = createMockJobService()
+    const manager = new Manager(shardManager, jobService)
+
+    await manager.start()
+
+    expect(spawn).toHaveBeenCalledOnce()
+    expect(jobService.start).toHaveBeenCalledOnce()
+  })
+
+  it('rethrows a shard spawn failure and does not start jobs', async () => {
+    const error = new Error('spawn failed')
+    const spawn = vi.fn().mockRejectedValue(error)
+    const shardManager = createMockShardManager(spawn)
+    const jobService = createMockJobService()
+    const manager = new Manager(shardManager, jobService)
+
+    await expect(manager.start()).rejects.toBe(error)
+
+    expect(jobService.start).not.toHaveBeenCalled()
+  })
+
+  it('kills partially spawned shards when spawning fails', async () => {
+    const error = new Error('spawn timed out')
+    const spawn = vi.fn().mockRejectedValue(error)
+    const shard = createMockShard()
+    const shardManager = createMockShardManager(spawn, new Map([[0, shard]]))
+    const manager = new Manager(shardManager, createMockJobService())
+
+    await expect(manager.start()).rejects.toBe(error)
+
+    expect(shard.kill).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
# Description

Fatal startup failures currently log an error and let the process keep going (or exit 0), so deployment tooling can't tell a broken start from a healthy one. Concretely: if shard spawning fails, the manager still starts its API, `/health` reports OK, and Coolify replaces a working container with a disconnected one.

This PR makes startup failures fatal and visible at the process boundary:

- `Manager.start()` rethrows shard spawn failures after killing any partially spawned shards. Because the error propagates, `start-manager` never starts the API and never reports ready to the master — a failed deploy now fails its health check instead of going green with zero shards.
- `start-manager` sets a non-zero exit code when shard retrieval fails, when the shard list is empty outside clustering (with clustering enabled, an empty assignment from the master remains a valid idle state), and on any error reaching the top-level catch.
- `Bot.login()` destroys the client and rethrows on login failure, so the bot process exits non-zero instead of idling disconnected forever.
- The `commands` CLI sets `process.exitCode = 1` when registration fails (previously it called `process.exit()` with no argument — exit 0 — after a failure). The calendar sync CLI keeps its existing behavior via `process.exitCode`.
- Runtime event-handler errors and `unhandledRejection` are intentionally unchanged: they log and continue.

`process.exitCode` is used instead of `process.exit(1)` wherever possible so pending logs flush naturally and tests can assert on exit behavior without killing the test runner.

Fixes #140
Fixes #142

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested? IMPORTANT

- [x] New unit tests: `tests/models/manager.test.ts` (successful spawn starts jobs; rejected spawn rethrows, skips jobs, kills partial shards) and `tests/models/bot.test.ts` (successful login; failed login rethrows and destroys the client)
- [x] `tsc --noEmit`, `eslint`, and `prettier --check` pass on all touched files
- [x] Full `vitest` run: the new tests pass; the remaining local failures are pre-existing on `dev` (environment-specific, reproduce on a clean checkout without this change)

**Test Configuration**:

- Local unit tests only; no live Discord or CRM calls

# Checklist:

- [x] I used an LLM to generate a portion of the code. > 10 %
- [x] My changes pass formatting and linting rules
- [x] I have added _unit_ tests that prove my fix is effective or that my feature works if needed
