### PR TITLE
Validate environment per runtime mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,9 @@ BACKUP_S3_ENDPOINT=
 BACKUP_S3_REGION=us-east-1
 BACKUP_S3_PREFIX=discord-bot/sqlite
 
-# CRM integration: required for /attendance-track to post staged attendance.
+# CRM integration: required at startup while config.json crm.enabled is true
+# (the default). Set crm.enabled to false to run without a CRM; /attendance-track
+# then hands out the list without syncing it.
 # Local dev: point at the in-house-mgmt server (default port 8080) and a token
 # created in Django admin → Auth → Tokens for a user in the DISCORD_BOT group.
 CRM_API_URL="http://localhost:8080"
@@ -37,9 +39,10 @@ CRM_API_TOKEN="paste-token-from-django-admin"
 #
 # Manager API auth: shared secret required in the Authorization header of
 # GET /guilds, GET /shards, and PUT /shards/presence. The manager refuses to
-# start without it. Use a long random value per environment.
+# start without it (bot and CLI modes don't need it). Use a long random value
+# per environment.
 DISCORD_BOT_API_SECRET="generate-a-long-random-string"
 
-# Required to start, but only sent anywhere when config.json clustering.enabled
-# is true (it is false by default). Any non-empty value works until then.
-DISCORD_BOT_MASTER_API_TOKEN="test-passing-var"
+# Only required when config.json clustering.enabled is true (it is false by
+# default); leave unset otherwise.
+# DISCORD_BOT_MASTER_API_TOKEN="master-api-token"

--- a/config/config.json
+++ b/config/config.json
@@ -39,6 +39,9 @@
     "spawnTimeout": 300,
     "serversPerShard": 1000
   },
+  "crm": {
+    "enabled": true
+  },
   "clustering": {
     "enabled": false,
     "shardCount": 16,

--- a/lang/lang.en-US.json
+++ b/lang/lang.en-US.json
@@ -158,6 +158,9 @@
       "attendancePermissionCheckFailed": {
         "description": "Tracking **{{CHANNEL_NAME}}**. ⚠️ Couldn't reach the CRM to verify your permissions, so attendance won't be synced. Leave the channel or run `/stop-attendance-track` to get the list."
       },
+      "attendanceCrmDisabled": {
+        "description": "Tracking **{{CHANNEL_NAME}}**. ⚠️ CRM attendance recording is disabled on this bot, so attendance won't be synced. Leave the channel or run `/stop-attendance-track` to get the list."
+      },
       "grantAccessAdded": {
         "description": "{{USER}} was added to the **{{TEAM_LABEL}}** Google Group."
       },

--- a/src/calendar-sync-cli.ts
+++ b/src/calendar-sync-cli.ts
@@ -1,7 +1,6 @@
 import { Events, Options, Partials } from 'discord.js'
 import { createRequire } from 'node:module'
 
-import './config/environment.js'
 import { CustomClient } from './extensions/index.js'
 import { GoogleCalendarService } from './services/index.js'
 import { syncDggpScheduledEventsToGoogle } from './services/sync-dggp-google-calendar.js'

--- a/src/commands/chat/attendance-track-command.ts
+++ b/src/commands/chat/attendance-track-command.ts
@@ -22,6 +22,7 @@ const REASON_TO_LANG_KEY: Record<CrmDisabledReason, string> = {
   not_authorized: 'displayEmbeds.attendanceNotAuthorized',
   unlinked_discord_id: 'displayEmbeds.attendanceUnlinkedDiscordId',
   check_failed: 'displayEmbeds.attendancePermissionCheckFailed',
+  crm_disabled: 'displayEmbeds.attendanceCrmDisabled',
 }
 
 export class AttendanceTrackCommand implements Command {
@@ -32,7 +33,7 @@ export class AttendanceTrackCommand implements Command {
 
   constructor(
     private readonly attendanceService: AttendanceService,
-    private readonly crmService: CrmService,
+    private readonly crmService?: CrmService,
   ) {}
 
   public async execute(intr: ChatInputCommandInteraction, data: EventData): Promise<void> {
@@ -68,17 +69,21 @@ export class AttendanceTrackCommand implements Command {
     }
 
     let crmDisabledReason: CrmDisabledReason | undefined
-    try {
-      const permission = await this.crmService.checkAttendancePermission(intr.user.id)
-      if (!permission.authorized) {
-        crmDisabledReason =
-          permission.reason === 'not_authorized' || permission.reason === 'unlinked_discord_id'
-            ? permission.reason
-            : 'check_failed'
+    if (!this.crmService) {
+      crmDisabledReason = 'crm_disabled'
+    } else {
+      try {
+        const permission = await this.crmService.checkAttendancePermission(intr.user.id)
+        if (!permission.authorized) {
+          crmDisabledReason =
+            permission.reason === 'not_authorized' || permission.reason === 'unlinked_discord_id'
+              ? permission.reason
+              : 'check_failed'
+        }
+      } catch (error) {
+        Logger.error('CRM can-record-attendance check failed', error)
+        crmDisabledReason = 'check_failed'
       }
-    } catch (error) {
-      Logger.error('CRM can-record-attendance check failed', error)
-      crmDisabledReason = 'check_failed'
     }
 
     const customName = intr.options.getString(

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -1,38 +1,59 @@
 import { config } from 'dotenv'
+import { createRequire } from 'node:module'
 
 if (process.env.NODE_ENV !== 'production') {
   config()
 }
 
-const requiredEnvVars = [
-  'DISCORD_CLIENT_ID',
-  'DISCORD_BOT_TOKEN',
-  'DISCORD_BOT_API_SECRET',
-  'DISCORD_BOT_MASTER_API_TOKEN',
-  'DISCORD_BOT_DEVELOPER_IDS',
-] as const
+const require = createRequire(import.meta.url)
+const Config = require('../../config/config.json')
 
-export function validateEnv(): void {
-  for (const envVar of requiredEnvVars) {
-    if (!process.env[envVar]) {
-      throw new Error(`Missing required environment variable: ${envVar}`)
-    }
-  }
+/**
+ * The processes this codebase can start as. Each mode requires only the
+ * environment variables it actually reads at runtime.
+ */
+export type RuntimeMode = 'bot' | 'manager' | 'commands' | 'calendar'
 
-  const snowflakePattern = /^\d{17,19}$/
-  const developerIds = process.env.DISCORD_BOT_DEVELOPER_IDS.split(',').map((id) => id.trim())
-  if (developerIds.length === 0) {
-    throw new Error('DISCORD_BOT_DEVELOPER_IDS must contain at least one ID')
-  }
-  for (const id of developerIds) {
-    if (!snowflakePattern.test(id)) {
-      throw new Error(`Invalid Discord ID in DISCORD_BOT_DEVELOPER_IDS: ${id}`)
-    }
-  }
+const modeEnvVars: Record<RuntimeMode, string[]> = {
+  bot: ['DISCORD_BOT_TOKEN', 'DISCORD_BOT_DEVELOPER_IDS'],
+  manager: ['DISCORD_BOT_TOKEN', 'DISCORD_BOT_API_SECRET'],
+  commands: ['DISCORD_BOT_TOKEN', 'DISCORD_CLIENT_ID'],
+  calendar: ['DISCORD_BOT_TOKEN'],
 }
 
-validateEnv()
-
 export function getDeveloperIds(): string[] {
-  return process.env.DISCORD_BOT_DEVELOPER_IDS.split(',').map((id) => id.trim())
+  return (process.env.DISCORD_BOT_DEVELOPER_IDS ?? '')
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean)
+}
+
+export function validateEnv(mode: RuntimeMode): void {
+  const required = [...modeEnvVars[mode]]
+  if (mode === 'manager' && Config.clustering.enabled) {
+    required.push('DISCORD_BOT_MASTER_API_TOKEN')
+  }
+  if (mode === 'bot' && Config.crm.enabled) {
+    required.push('CRM_API_URL', 'CRM_API_TOKEN')
+  }
+
+  const missing = required.filter((envVar) => !process.env[envVar])
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variable(s) for ${mode} mode: ${missing.join(', ')}`,
+    )
+  }
+
+  if (required.includes('DISCORD_BOT_DEVELOPER_IDS')) {
+    const snowflakePattern = /^\d{17,19}$/
+    const developerIds = getDeveloperIds()
+    if (developerIds.length === 0) {
+      throw new Error('DISCORD_BOT_DEVELOPER_IDS must contain at least one ID')
+    }
+    for (const id of developerIds) {
+      if (!snowflakePattern.test(id)) {
+        throw new Error(`Invalid Discord ID in DISCORD_BOT_DEVELOPER_IDS: ${id}`)
+      }
+    }
+  }
 }

--- a/src/controllers/guilds-controller.ts
+++ b/src/controllers/guilds-controller.ts
@@ -8,7 +8,8 @@ export class GuildsController implements Controller {
   public path = '/guilds'
   public router: Router = Router()
   public requiresAuth = true
-  public authToken: string = process.env.DISCORD_BOT_API_SECRET
+  // Validated in manager mode; an empty token fails closed in checkAuth.
+  public authToken: string = process.env.DISCORD_BOT_API_SECRET ?? ''
 
   constructor(private shardManager: ShardingManager) {}
 

--- a/src/controllers/shards-controller.ts
+++ b/src/controllers/shards-controller.ts
@@ -20,7 +20,8 @@ export class ShardsController implements Controller {
   public path = '/shards'
   public router: Router = Router()
   public requiresAuth = true
-  public authToken: string = process.env.DISCORD_BOT_API_SECRET
+  // Validated in manager mode; an empty token fails closed in checkAuth.
+  public authToken: string = process.env.DISCORD_BOT_API_SECRET ?? ''
 
   constructor(private shardManager: ShardingManager) {}
 

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -1,14 +1,25 @@
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      DISCORD_CLIENT_ID: string
+      // Required in every runtime mode; validated by validateEnv() at each
+      // entry point.
       DISCORD_BOT_TOKEN: string
-      DISCORD_BOT_API_SECRET: string
-      DISCORD_BOT_MASTER_API_TOKEN: string
-      DISCORD_BOT_DEVELOPER_IDS: string // comma-separated list of Discord user IDs
+      // Required per mode/capability — see src/config/environment.ts.
+      DISCORD_CLIENT_ID?: string // commands CLI
+      DISCORD_BOT_API_SECRET?: string // manager
+      DISCORD_BOT_MASTER_API_TOKEN?: string // manager, when clustering is enabled
+      DISCORD_BOT_DEVELOPER_IDS?: string // bot; comma-separated list of Discord user IDs
+      CRM_API_URL?: string // bot, when crm is enabled
+      CRM_API_TOKEN?: string // bot, when crm is enabled
+      // Optional integrations and overrides.
       INTEGRATION_DM_PROXY?: string // unset disables the /integrations/send-dm endpoint
       PORT?: string // overrides config.api.port when set (injected by the hosting platform)
-      SQLITE_PATH: string
+      SQLITE_PATH?: string // unset disables the database-backed features
+      GOOGLE_CALENDAR_ID?: string
+      GOOGLE_CALENDAR_CREDENTIALS?: string
+      GOOGLE_APPLICATION_CREDENTIALS?: string
+      GOOGLE_CALENDAR_IMPERSONATION_SUBJECT?: string
+      GOOGLE_WORKSPACE_ADMIN_SUBJECT?: string
       NODE_ENV: 'development' | 'production' | 'test'
     }
   }

--- a/src/events/voice-state-update-handler.ts
+++ b/src/events/voice-state-update-handler.ts
@@ -28,12 +28,14 @@ const CRM_DISABLED_DM_NOTES: Record<CrmDisabledReason, string> = {
     "Your Discord account isn't linked to a CRM user, so this list wasn't synced — keep it for your records.",
   check_failed:
     "The CRM was unreachable when tracking started, so this list wasn't synced — keep it for your records.",
+  crm_disabled:
+    "CRM attendance recording is disabled on this bot, so this list wasn't synced — keep it for your records.",
 }
 
 export class VoiceStateUpdateHandler implements EventHandler {
   constructor(
     private readonly attendanceService: AttendanceService,
-    private readonly crmService: CrmService,
+    private readonly crmService: CrmService | undefined,
     private readonly client: Client,
   ) {}
 
@@ -70,14 +72,15 @@ export class VoiceStateUpdateHandler implements EventHandler {
       const displayEventName = customEventName ?? scheduledEvent?.name ?? defaultEventName
       const finalizedAt = new Date()
 
-      if (crmDisabledReason) {
+      const crmService = this.crmService
+      if (crmDisabledReason || !crmService) {
         await this.sendAttendanceFallbackDms(
           user,
           channelName,
           displayEventName,
           entries,
           finalizedAt,
-          CRM_DISABLED_DM_NOTES[crmDisabledReason],
+          CRM_DISABLED_DM_NOTES[crmDisabledReason ?? 'crm_disabled'],
           null,
         )
         return
@@ -95,7 +98,7 @@ export class VoiceStateUpdateHandler implements EventHandler {
       }
 
       try {
-        const response = await this.crmService.recordAttendance(payload)
+        const response = await crmService.recordAttendance(payload)
 
         try {
           const sent = await this.sendCrmSuccessDm(

--- a/src/services/attendance-service.ts
+++ b/src/services/attendance-service.ts
@@ -139,7 +139,11 @@ export async function resolveVoiceChannelMeetingSubject(
  * permission check rejects or errors. Tracking still proceeds; the handler skips the CRM call
  * at session end and tells the user why.
  */
-export type CrmDisabledReason = 'not_authorized' | 'unlinked_discord_id' | 'check_failed'
+export type CrmDisabledReason =
+  | 'not_authorized'
+  | 'unlinked_discord_id'
+  | 'check_failed'
+  | 'crm_disabled'
 
 interface AttendanceSession {
   /** Synthetic identifier used as event_id when no Discord scheduled event is linked.

--- a/src/services/command-registration-service.ts
+++ b/src/services/command-registration-service.ts
@@ -7,20 +7,27 @@ import {
   Routes,
 } from 'discord.js'
 
-import '../config/environment.js'
 import { Logger } from './logger.js'
 
 import Logs from '../../lang/logs.json' with { type: 'json' }
 
 export class CommandRegistrationService {
-  constructor(private rest: REST) {}
+  private clientId: string
+
+  constructor(private rest: REST) {
+    const clientId = process.env.DISCORD_CLIENT_ID
+    if (!clientId) {
+      throw new Error('DISCORD_CLIENT_ID must be set to manage commands')
+    }
+    this.clientId = clientId
+  }
 
   public async process(
     localCmds: RESTPostAPIApplicationCommandsJSONBody[],
     args: string[],
   ): Promise<void> {
     const remoteCmds = (await this.rest.get(
-      Routes.applicationCommands(process.env.DISCORD_CLIENT_ID),
+      Routes.applicationCommands(this.clientId),
     )) as RESTGetAPIApplicationCommandsResult
 
     const localCmdsOnRemote = localCmds.filter((localCmd) =>
@@ -52,7 +59,7 @@ export class CommandRegistrationService {
             ),
           )
           for (const localCmd of localCmdsOnly) {
-            await this.rest.post(Routes.applicationCommands(process.env.DISCORD_CLIENT_ID), {
+            await this.rest.post(Routes.applicationCommands(this.clientId), {
               body: localCmd,
             })
           }
@@ -67,7 +74,7 @@ export class CommandRegistrationService {
             ),
           )
           for (const localCmd of localCmdsOnRemote) {
-            await this.rest.post(Routes.applicationCommands(process.env.DISCORD_CLIENT_ID), {
+            await this.rest.post(Routes.applicationCommands(this.clientId), {
               body: localCmd,
             })
           }
@@ -98,12 +105,9 @@ export class CommandRegistrationService {
         const body: RESTPatchAPIApplicationCommandJSONBody = {
           name: newName,
         }
-        await this.rest.patch(
-          Routes.applicationCommand(process.env.DISCORD_CLIENT_ID, remoteCmd.id),
-          {
-            body,
-          },
-        )
+        await this.rest.patch(Routes.applicationCommand(this.clientId, remoteCmd.id), {
+          body,
+        })
         Logger.info(Logs.info.commandActionRenamed)
         return
       }
@@ -121,9 +125,7 @@ export class CommandRegistrationService {
         }
 
         Logger.info(Logs.info.commandActionDeleting.replaceAll('{COMMAND_NAME}', remoteCmd.name))
-        await this.rest.delete(
-          Routes.applicationCommand(process.env.DISCORD_CLIENT_ID, remoteCmd.id),
-        )
+        await this.rest.delete(Routes.applicationCommand(this.clientId, remoteCmd.id))
         Logger.info(Logs.info.commandActionDeleted)
         return
       }
@@ -134,7 +136,7 @@ export class CommandRegistrationService {
             this.formatCommandList(remoteCmds),
           ),
         )
-        await this.rest.put(Routes.applicationCommands(process.env.DISCORD_CLIENT_ID), { body: [] })
+        await this.rest.put(Routes.applicationCommands(this.clientId), { body: [] })
         Logger.info(Logs.info.commandActionCleared)
         return
       }

--- a/src/services/master-api-service.ts
+++ b/src/services/master-api-service.ts
@@ -14,18 +14,27 @@ export class MasterApiService {
 
   constructor(private httpService: HttpService) {}
 
+  // Only read when clustering is enabled, which requires this variable.
+  private get masterApiToken(): string {
+    const token = process.env.DISCORD_BOT_MASTER_API_TOKEN
+    if (!token) {
+      throw new Error('DISCORD_BOT_MASTER_API_TOKEN must be set when clustering is enabled')
+    }
+    return token
+  }
+
   public async register(): Promise<void> {
     const reqBody: RegisterClusterRequest = {
       shardCount: Config.clustering.shardCount,
       callback: {
         url: Config.clustering.callbackUrl,
-        token: process.env.DISCORD_BOT_API_SECRET,
+        token: process.env.DISCORD_BOT_API_SECRET ?? '',
       },
     }
 
     const res = await this.httpService.post(
       new URL('/clusters', Config.clustering.masterApi.url),
-      process.env.DISCORD_BOT_MASTER_API_TOKEN,
+      this.masterApiToken,
       reqBody,
     )
 
@@ -40,7 +49,7 @@ export class MasterApiService {
   public async login(): Promise<LoginClusterResponse> {
     const res = await this.httpService.put(
       new URL(`/clusters/${this.clusterId}/login`, Config.clustering.masterApi.url),
-      process.env.DISCORD_BOT_MASTER_API_TOKEN,
+      this.masterApiToken,
     )
 
     if (!res.ok) {
@@ -53,7 +62,7 @@ export class MasterApiService {
   public async ready(): Promise<void> {
     const res = await this.httpService.put(
       new URL(`/clusters/${this.clusterId}/ready`, Config.clustering.masterApi.url),
-      process.env.DISCORD_BOT_MASTER_API_TOKEN,
+      this.masterApiToken,
     )
 
     if (!res.ok) {

--- a/src/start-bot.ts
+++ b/src/start-bot.ts
@@ -25,6 +25,7 @@ import {
   UserCommandMetadata,
   type Command,
 } from './commands/index.js'
+import { validateEnv } from './config/environment.js'
 import { ONBOARDING_CONFIGS, SendOnboarding } from './commands/user/index.js'
 import { createDatabase, type Database } from './database/index.js'
 import {
@@ -75,6 +76,7 @@ async function flushLogsAndExit(): Promise<never> {
 
 async function start(): Promise<void> {
   if (process.argv[2] === 'calendar' && process.argv[3] === 'sync') {
+    validateEnv('calendar')
     try {
       await runCalendarSyncCli()
     } catch (error) {
@@ -86,6 +88,7 @@ async function start(): Promise<void> {
 
   // Register
   if (process.argv[2] == 'commands') {
+    validateEnv('commands')
     try {
       const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_BOT_TOKEN)
       const commandRegistrationService = new CommandRegistrationService(rest)
@@ -102,10 +105,15 @@ async function start(): Promise<void> {
     await flushLogsAndExit()
   }
 
+  validateEnv('bot')
+
   // Services
   const eventDataService = new EventDataService()
   const attendanceService = new AttendanceService()
-  const crmService = new CrmService()
+  const crmService = Config.crm.enabled ? new CrmService() : undefined
+  if (!crmService) {
+    Logger.warn('CRM integration disabled via config — attendance will not be recorded in the CRM.')
+  }
 
   // Client
   const client = new CustomClient({

--- a/src/start-manager.ts
+++ b/src/start-manager.ts
@@ -9,6 +9,7 @@ import {
   RootController,
   ShardsController,
 } from './controllers/index.js'
+import { validateEnv } from './config/environment.js'
 import {
   DmProxyIntegration,
   type Integration,
@@ -26,6 +27,8 @@ const Debug = require('../config/debug.json')
 const Logs = require('../lang/logs.json')
 
 async function start(): Promise<void> {
+  validateEnv('manager')
+
   Logger.info(Logs.info.appStarted)
 
   // Dependencies

--- a/tests/config/environment.test.ts
+++ b/tests/config/environment.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getDeveloperIds, validateEnv } from '../../src/config/environment.js'
+
+const VALID_ID = '123456789012345678'
+
+const ALL_VARS = [
+  'DISCORD_BOT_TOKEN',
+  'DISCORD_CLIENT_ID',
+  'DISCORD_BOT_API_SECRET',
+  'DISCORD_BOT_MASTER_API_TOKEN',
+  'DISCORD_BOT_DEVELOPER_IDS',
+  'CRM_API_URL',
+  'CRM_API_TOKEN',
+] as const
+
+function stubEnv(values: Partial<Record<(typeof ALL_VARS)[number], string>>): void {
+  for (const envVar of ALL_VARS) {
+    vi.stubEnv(envVar, values[envVar] ?? '')
+  }
+}
+
+describe('validateEnv', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('bot mode', () => {
+    it('passes with the bot variables set', () => {
+      stubEnv({
+        DISCORD_BOT_TOKEN: 'token',
+        DISCORD_BOT_DEVELOPER_IDS: VALID_ID,
+        CRM_API_URL: 'http://localhost:8080',
+        CRM_API_TOKEN: 'crm-token',
+      })
+
+      expect(() => validateEnv('bot')).not.toThrow()
+    })
+
+    it('does not require manager or commands variables', () => {
+      stubEnv({
+        DISCORD_BOT_TOKEN: 'token',
+        DISCORD_BOT_DEVELOPER_IDS: VALID_ID,
+        CRM_API_URL: 'http://localhost:8080',
+        CRM_API_TOKEN: 'crm-token',
+      })
+
+      // DISCORD_CLIENT_ID, DISCORD_BOT_API_SECRET, and
+      // DISCORD_BOT_MASTER_API_TOKEN are unset above.
+      expect(() => validateEnv('bot')).not.toThrow()
+    })
+
+    it('requires the CRM variables while crm is enabled in config', () => {
+      stubEnv({
+        DISCORD_BOT_TOKEN: 'token',
+        DISCORD_BOT_DEVELOPER_IDS: VALID_ID,
+      })
+
+      expect(() => validateEnv('bot')).toThrow(/CRM_API_URL, CRM_API_TOKEN/)
+    })
+
+    it('rejects an empty developer ID list', () => {
+      stubEnv({
+        DISCORD_BOT_TOKEN: 'token',
+        DISCORD_BOT_DEVELOPER_IDS: ' , ',
+        CRM_API_URL: 'http://localhost:8080',
+        CRM_API_TOKEN: 'crm-token',
+      })
+
+      expect(() => validateEnv('bot')).toThrow(/at least one ID/)
+    })
+
+    it('rejects developer IDs that are not snowflakes', () => {
+      stubEnv({
+        DISCORD_BOT_TOKEN: 'token',
+        DISCORD_BOT_DEVELOPER_IDS: `${VALID_ID},not-a-snowflake`,
+        CRM_API_URL: 'http://localhost:8080',
+        CRM_API_TOKEN: 'crm-token',
+      })
+
+      expect(() => validateEnv('bot')).toThrow(/not-a-snowflake/)
+    })
+  })
+
+  describe('manager mode', () => {
+    it('passes with the manager variables set', () => {
+      stubEnv({
+        DISCORD_BOT_TOKEN: 'token',
+        DISCORD_BOT_API_SECRET: 'secret',
+      })
+
+      // DISCORD_BOT_MASTER_API_TOKEN stays unset: clustering is disabled in
+      // config, so it must not be required.
+      expect(() => validateEnv('manager')).not.toThrow()
+    })
+
+    it('requires the API secret', () => {
+      stubEnv({ DISCORD_BOT_TOKEN: 'token' })
+
+      expect(() => validateEnv('manager')).toThrow(/DISCORD_BOT_API_SECRET/)
+    })
+
+    it('reports all missing variables in one error', () => {
+      stubEnv({})
+
+      expect(() => validateEnv('manager')).toThrow(/DISCORD_BOT_TOKEN, DISCORD_BOT_API_SECRET/)
+    })
+  })
+
+  describe('commands mode', () => {
+    it('passes with the token and client ID set', () => {
+      stubEnv({
+        DISCORD_BOT_TOKEN: 'token',
+        DISCORD_CLIENT_ID: 'client-id',
+      })
+
+      expect(() => validateEnv('commands')).not.toThrow()
+    })
+
+    it('requires the client ID', () => {
+      stubEnv({ DISCORD_BOT_TOKEN: 'token' })
+
+      expect(() => validateEnv('commands')).toThrow(/DISCORD_CLIENT_ID/)
+    })
+  })
+
+  describe('calendar mode', () => {
+    it('requires only the token', () => {
+      stubEnv({ DISCORD_BOT_TOKEN: 'token' })
+
+      expect(() => validateEnv('calendar')).not.toThrow()
+    })
+
+    it('requires the token', () => {
+      stubEnv({})
+
+      expect(() => validateEnv('calendar')).toThrow(/DISCORD_BOT_TOKEN/)
+    })
+  })
+})
+
+describe('getDeveloperIds', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('splits and trims the configured IDs', () => {
+    vi.stubEnv('DISCORD_BOT_DEVELOPER_IDS', ` ${VALID_ID} , 987654321098765432 `)
+
+    expect(getDeveloperIds()).toEqual([VALID_ID, '987654321098765432'])
+  })
+
+  it('returns an empty list when unset', () => {
+    vi.stubEnv('DISCORD_BOT_DEVELOPER_IDS', '')
+
+    expect(getDeveloperIds()).toEqual([])
+  })
+})


### PR DESCRIPTION
# Description

> Stacked on #168: this branch is based on `arnanh/fatal-startup-exit-codes` so that a validation failure at an entry point exits non-zero. Merge that one first; this PR's base is set to it and will retarget to `dev` when it merges.

Environment requirements were previously split across an import-time side effect, service constructors, and a global `ProcessEnv` that typed everything as always-present. Every mode required all five `DISCORD_*` variables — including dummy clustering secrets for a feature that's disabled — while the CRM variables were required in practice (the `CrmService` constructor throws) but invisible to validation.

This PR aligns validation, types, and runtime modes:

- `validateEnv(mode)` validates only what each process reads: `bot`, `manager`, `commands`, and `calendar` each declare their own requirements, and each entry point calls it explicitly at startup. The import-time `validateEnv()` side effect is gone (the `dotenv` load remains).
- `DISCORD_BOT_MASTER_API_TOKEN` is only required when `clustering.enabled` is true; `DISCORD_BOT_API_SECRET` is only required in manager mode (the manager API always runs and its auth fails closed on an empty token).
- CRM credentials are governed by a new `crm.enabled` config flag, **enabled by default** so production behavior is unchanged and a missing/typo'd CRM variable fails the deploy loudly instead of silently dropping attendance data. With `crm.enabled: false`, the bot starts without dummy secrets and `/attendance-track` still works — it tells the tracker up front that CRM sync is off and DMs the roster with a note at session end (new `crm_disabled` reason alongside the existing per-user ones).
- `ProcessEnv` types now match runtime optionality: conditionally required and optional variables are `?`-typed (`SQLITE_PATH`, `DISCORD_CLIENT_ID`, the secrets, CRM), and the Google/CRM variables the code actually reads are declared. Call sites were updated to handle this honestly (`CommandRegistrationService` captures a validated client ID; `MasterApiService` guards the master token; controllers fall back to an empty token that `checkAuth` rejects).
- All missing variables for a mode are reported in a single clear error.
- `.env.example` comments updated to match (master API token is now commented out instead of "any non-empty value works").

Fixes #145

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested? IMPORTANT

- [x] New unit tests: `tests/config/environment.test.ts` — per-mode pass/fail cases for all four modes, clustering-gated master token, CRM requirement while `crm.enabled`, developer ID snowflake validation, combined missing-variable error, and `getDeveloperIds` parsing (14 tests)
- [x] `tsc --noEmit`, `eslint`, and `prettier --check` pass on all touched files
- [x] Full `vitest` run: the new tests pass; the remaining local failures are pre-existing on `dev` (environment-specific, reproduce on a clean checkout without this change)

**Test Configuration**:

- Local unit tests only; no live Discord or CRM calls

# Checklist:

- [x] I used an LLM to generate a portion of the code. > 10 %
- [x] My changes pass formatting and linting rules
- [x] I have added _unit_ tests that prove my fix is effective or that my feature works if needed
