### PR TITLE
fix: ignore StickyBot posts in the CTA trigger

### DIFF
--- a/src/triggers/cta-post.ts
+++ b/src/triggers/cta-post.ts
@@ -30,6 +30,8 @@ const regionRoles = [
   'West Coast Squad',
   'International Squad',
 ]
+// authors whose posts should never get a completion thread
+const ignoredAuthorNames = ['stickybot']
 const finishedEmoji = '✅'
 const oneHour = 3_600_000
 const activeCollectors = new Map()
@@ -40,6 +42,10 @@ export class CTAPostTrigger implements Trigger {
   chanThreadsByMsg = new Map()
 
   public triggered(msg: Message): boolean {
+    if (this.isIgnoredAuthor(msg)) {
+      return false
+    }
+
     /* eslint-disable @typescript-eslint/no-shadow */
     const ctaChannel = msg.guild?.channels.cache.find(
       (ctaChannel) => ctaChannel?.name === channelName,
@@ -85,6 +91,15 @@ export class CTAPostTrigger implements Trigger {
     if (thread) {
       await this.startCTAReactionCollector(msg, thread)
     }
+  }
+
+  private isIgnoredAuthor(msg: Message): boolean {
+    const names = [msg.author.username, msg.author.globalName, msg.member?.displayName]
+
+    return names.some(
+      (name) =>
+        name !== undefined && name !== null && ignoredAuthorNames.includes(name.toLowerCase()),
+    )
   }
 
   private async getFinishedReactions(msg: Message): Promise<object> {


### PR DESCRIPTION
# Description

StickyBot posts announcements in `#call-to-action`, and those posts do not need a completion thread attached to them. This adds an early bail to `CTAPostTrigger.triggered()` for ignored authors, so an ignored post creates no thread, no reaction collector, and no chart.

Author matching is case-insensitive against `msg.author.username`, `msg.author.globalName`, and `msg.member?.displayName`, driven by an `ignoredAuthorNames` constant alongside the existing `channelName` / `regionRoles` constants in the same file.

Fixes #165

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested? IMPORTANT

**Not yet tested — this needs a reviewer or a follow-up commit before merge.**

- [ ] Verified in the dev Discord server that a StickyBot post in `#call-to-action` gets no completion thread
- [ ] Verified a normal human CTA post still gets its thread, collector, and chart
- [ ] `npm run check-types` / `npm run lint`

**Test Configuration**:

- Integrations(Dev/Stage Discord Server)
- Local DB/State

# Checklist:

- [x] I have performed a self-review of my own code, especially if LLM generated
- [x] I used an LLM to generate a portion of the code. > 10 %
- [ ] I have made corresponding changes to the documentation
- [ ] My changes pass formatting and linting rules
- [ ] I have added _unit_ tests that prove my fix is effective or that my feature works if needed

## Reviewer notes / open questions

Two things I flagged and deliberately left as-is, worth a reviewer's opinion:

1. **Name matching is fragile.** Discord usernames and per-guild display names are user-controlled and mutable. If StickyBot is renamed the filter silently stops working, and any human who sets their server nickname to `stickybot` would have their CTA posts silently ignored. Matching on the bot's immutable user ID (snowflake) would be robust against both, optionally via `config/config.json`.
2. **Assumes StickyBot posts as a bot user, not a webhook.** The name check happens to work either way, but if it posts via webhook then `globalName` is `null` and `msg.member` is `undefined`, and an ID-based check would need `msg.webhookId` instead. Worth confirming against the real server.

There are currently no tests under `tests/` covering `src/triggers/`, so this adds none — but `triggered()` is public and testable with a stubbed message object if we want a cheap guard.
